### PR TITLE
modify tox.ini to use nose instead of unittest2, same as .travis.yml

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,5 @@ envlist = py27, py33, py35
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
-       unittest2
-commands = unit2 discover []
-
-[testenv:py33]
-deps = -r{toxinidir}/requirements.txt
-       unittest2py3k
+       nose
+commands = nosetests []


### PR DESCRIPTION
The tox.ini file was set up to use unittest2 and unittest2py3k, which was kind of weird since unittest2 was really only necessary for python versions < 2.7 (the tox.ini only has versions >= 2.7). I modified the tox.ini to use nose, which is also already included in the requirements.txt and used by the .travis.yml.