### PR TITLE
Fixed issue #18 : when function as **kwargs, keep unknown kwargs for key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ docs/_build/*
 *.egg-info
 build/*
 dist/
+.idea/
+.idea/*

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+Version 1.1.1 2017-02-02
+````````````````````````
+
+  - Allows functions with kwargs to be memoized correctly. See `#18 <https://github.com/sh4nks/flask-caching/issues/18>`_.
+
 Version 1.1.1 2016-12-09
 ````````````````````````
 

--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -488,6 +488,8 @@ class Cache(object):
         new_args = []
         arg_num = 0
 
+        # If the function uses VAR_KEYWORD type of parameters, we need to pass these further
+        kwargs_keys_remaining = list(kwargs.keys())
         arg_names = get_arg_names(f)
         args_len = len(arg_names)
 
@@ -502,6 +504,7 @@ class Cache(object):
                 arg_num += 1
             elif arg_names[i] in kwargs:
                 arg = kwargs[arg_names[i]]
+                kwargs_keys_remaining.pop(kwargs_keys_remaining.index(arg_names[i]))
             elif arg_num < len(args):
                 arg = args[arg_num]
                 arg_num += 1
@@ -533,7 +536,9 @@ class Cache(object):
 
             new_args.append(arg)
 
-        return tuple(new_args), {}
+        return tuple(new_args), {
+            k: v for k, v in kwargs.items() if k in kwargs_keys_remaining
+        }
 
     def _bypass_cache(self, unless, f, *args, **kwargs):
         """Determines whether or not to bypass the cache by calling unless().

--- a/test_cache.py
+++ b/test_cache.py
@@ -351,6 +351,22 @@ class CacheTestCase(unittest.TestCase):
             with self.assertRaises(TypeError):
                 f(1)
 
+    def test_10a_arg_kwarg_memoize_var_keyword(self):
+        with self.app.test_request_context():
+            @self.cache.memoize()
+            def f(a, b, c=1, **kwargs):
+                return a + b + c + random.randrange(0, 100000) + sum(list(kwargs.values()))
+
+            assert f(1, 2) == f(1, 2, c=1)
+            assert f(1, 2) == f(1, 2, 1)
+            assert f(1, 2) == f(1, 2)
+            assert f(1, 2, d=5, e=8) == f(1, 2, e=8, d=5)
+            assert f(1, b=2, c=3, d=5, e=8) == f(1, 2, e=8, d=5, b=2, c=3)
+            assert f(1, 2, 3) != f(1, 2)
+            assert f(1, 2, 3) != f(1, 2)
+            with self.assertRaises(TypeError):
+                f(1)
+
     def test_10b_classarg_memoize(self):
         @self.cache.memoize()
         def bar(a):


### PR DESCRIPTION
I don't know how this would work for *args but at least it works for kwargs ;)
If I find myself in the *args situation and this bugs, I'll propose a second patch