### PR TITLE
Specify Werkzeug version requirement (fix #37)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,8 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'Flask'
+        'Flask',
+        'Werkzeug>=0.12',
     ],
     tests_require=['pytest'],
     cmdclass={'test': PyTest},


### PR DESCRIPTION
This PR avoid breakage for environment with Werkzeug<0.12 already installed because the uwsgi backend depends on Werkzeug 0.12+