### PR TITLE
Support multiple params and use md5 for consistent hashing

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -398,13 +398,14 @@ class Cache(object):
                 # provided.
                 args_as_sorted_tuple = tuple(
                     sorted(
-                        (pair for pair in request.args.items()),
-                        key=itemgetter(0),
+                        (pair for pair in request.args.items(multi=True))
                     )
                 )
                 # ... now hash the sorted (key, value) tuple so it can be
-                # used as a key for cache.
-                hashed_args = str(hash(args_as_sorted_tuple))
+                # used as a key for cache. Turn them into bytes so that md5
+                # will accept them
+                args_as_bytes = str(args_as_sorted_tuple).encode()
+                hashed_args = str(hashlib.md5(args_as_bytes).hexdigest())
                 cache_key = request.path + hashed_args
                 return cache_key
 

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -258,25 +258,11 @@ def test_generate_cache_key_from_query_string(app, cache):
     assert not third_time == second_time
 
 def test_generate_cache_key_from_query_string_repeated_paramaters(app, cache):
-    """Test the _make_cache_key_query_string() cache key maker.
+    """Test the _make_cache_key_query_string() cache key maker's support for
+    repeated query paramaters
 
-    Create three requests to verify that the same query string
-    parameters (key/value) always reference the same cache,
-    regardless of the order of parameters.
-
-    Also test to make sure that the same cache isn't being used for
-    any/all query string parameters.
-
-    For example, these two requests should yield the same
-    cache/cache key:
-
-      * GET /v1/works?mock=true&offset=20&limit=15
-      * GET /v1/works?limit=15&mock=true&offset=20
-
-    Caching functionality is verified by a `@cached` route `/works` which
-    produces a time in its response. The time in the response can verify that
-    two requests with the same query string parameters/values, though
-    differently ordered, produce responses with the same time.
+    URL params can be repeated with different values. Flask's MultiDict
+    supports them
     """
 
     @app.route('/works')

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import time
+from flask import request
 
 
 def test_cached_view(app, cache):
@@ -268,7 +269,8 @@ def test_generate_cache_key_from_query_string_repeated_paramaters(app, cache):
     @app.route('/works')
     @cache.cached(query_string=True)
     def view_works():
-        return str(time.time())
+        flatted_values = sum(request.args.listvalues(), [])
+        return str(sorted(flatted_values)) + str(time.time())
 
     tc = app.test_client()
 


### PR DESCRIPTION
This PR fixes a couple of issues I found with the `query_string=True` implementation

- Python 3 now randomizes `hash` on each start up. [Docs](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHASHSEED) This means that if you reuse the cache across flask deploys or multiple apps deployed behind a load balancer, you will have extra cache misses.
- URL params can be repeated. The current implementation ignored that and built the cache from the first repeated url param