### PR TITLE
Raise an exception when using `delete_memoized` incorrectly on a classmethod

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -93,6 +93,11 @@ def function_namespace(f, args=None):
 
     module = f.__module__
 
+    if m_args and m_args[0] == 'cls' and not inspect.isclass(args[0]):
+        raise ValueError('When using `delete_memoized` on a '
+                         '`@classmethod` you must provide the '
+                         'class as the first argument')
+
     if hasattr(f, '__qualname__'):
         name = f.__qualname__
     else:


### PR DESCRIPTION
Currently there's no test case for using `delete_memoized` with arguments on a `@classmethod`.
Unfortunately the way you do that isn't very developer friendly, as you need to pass in the class itself as the first argument:

```
class Simulator(object):
    @classmethod
    @cache.memoize(5)
    def position_of_star(cls, a, b):
        return a + b + random.randrange(0, 100000)

cache.delete_memoized(Simulator.position_of_star, Simulator, 5, 2)
```
Because of that this PR also adds that an exception is raised if a class is not passed as the first argument to `delete_memoized`, when using it on a `@classmethod`.

It would be better to get the class some other way than forcing it to be passed in, but it seems that that's not possible:
https://stackoverflow.com/a/5075252 and https://stackoverflow.com/a/19228282 (`f.__self__` and `f.im_class` doesn't seem to lead anywhere for a `@classmethod`)