### PR TITLE
Fix travis coveralls support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
  - "3.6"
 install:
  - pip install -r requirements.txt
+ - pip install coveralls
  - pip install --editable .
 script: py.test
 services:


### PR DESCRIPTION
This should resolve the `coveralls: command not found` errors at the end of each travis build.