### PR TITLE
Make key_prefix work as a prefix even when it's a callable.

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -416,8 +416,9 @@ class Cache(object):
 
             def _make_cache_key(args, kwargs, use_request):
                 if callable(key_prefix):
-                    cache_key = key_prefix()
-                elif '%s' in key_prefix:
+                    key_prefix = key_prefix()
+                
+                if '%s' in key_prefix:
                     if use_request:
                         cache_key = key_prefix % request.path
                     else:


### PR DESCRIPTION
Potentially a breaking change but to me, it's more consistent with the naming.