### PR TITLE
Memoize Try Except

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -666,10 +666,10 @@ class Cache(object):
                 if self._bypass_cache(unless, f, *args, **kwargs):
                     return f(*args, **kwargs)
 
-                cache_key = decorated_function.make_cache_key(
-                    f, *args, **kwargs
-                )
                 try:
+                    cache_key = decorated_function.make_cache_key(
+                        f, *args, **kwargs
+                    )
 
                     if callable(forced_update) and forced_update() is True:
                         rv = None

--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -666,6 +666,7 @@ class Cache(object):
                 if self._bypass_cache(unless, f, *args, **kwargs):
                     return f(*args, **kwargs)
 
+
                 try:
                     cache_key = decorated_function.make_cache_key(
                         f, *args, **kwargs
@@ -676,8 +677,6 @@ class Cache(object):
                     else:
                         rv = self.cache.get(cache_key)
                 except Exception:
-                    if current_app.debug:
-                        raise
                     logger.exception("Exception possibly due to "
                                      "cache backend.")
                     return f(*args, **kwargs)
@@ -690,8 +689,6 @@ class Cache(object):
                             timeout=decorated_function.cache_timeout
                         )
                     except Exception:
-                        if current_app.debug:
-                            raise
                         logger.exception("Exception possibly due to "
                                          "cache backend.")
                 return rv

--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -357,8 +357,6 @@ class Cache(object):
                     else:
                         rv = self.cache.get(cache_key)
                 except Exception:
-                    if current_app.debug:
-                        raise
                     logger.exception("Exception possibly due to "
                                      "cache backend.")
                     return f(*args, **kwargs)
@@ -371,8 +369,6 @@ class Cache(object):
                             timeout=decorated_function.cache_timeout
                         )
                     except Exception:
-                        if current_app.debug:
-                            raise
                         logger.exception("Exception possibly due to "
                                          "cache backend.")
                 return rv

--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -357,6 +357,8 @@ class Cache(object):
                     else:
                         rv = self.cache.get(cache_key)
                 except Exception:
+                    if self.app.debug:
+                        raise
                     logger.exception("Exception possibly due to "
                                      "cache backend.")
                     return f(*args, **kwargs)
@@ -369,6 +371,8 @@ class Cache(object):
                             timeout=decorated_function.cache_timeout
                         )
                     except Exception:
+                        if self.app.debug:
+                            raise
                         logger.exception("Exception possibly due to "
                                          "cache backend.")
                 return rv
@@ -673,6 +677,8 @@ class Cache(object):
                     else:
                         rv = self.cache.get(cache_key)
                 except Exception:
+                    if self.app.debug:
+                        raise
                     logger.exception("Exception possibly due to "
                                      "cache backend.")
                     return f(*args, **kwargs)
@@ -685,6 +691,8 @@ class Cache(object):
                             timeout=decorated_function.cache_timeout
                         )
                     except Exception:
+                        if self.app.debug:
+                            raise
                         logger.exception("Exception possibly due to "
                                          "cache backend.")
                 return rv


### PR DESCRIPTION
This PR:


- Adds a Try Except to the memoize function that mirrors the functionality that exists in `cache`.  Basically if the application *cannot* reach the cache, it shouldn't error out, but rather return the call seamlessly without using the cache. This was done in the `cache` decorator but was never ported to the memoize function. 

- Also, noticed that when there is an exception, it checks to see if the app has debug enabled and if it does, raises the exception. However calling current app causes an exception itself, as it is not in the application context at that time. I changed these calls to use `self.app` instead which works as the cache is instantiated with the current app. Below is the error I was running into when current_app was called.

```
Traceback (most recent call last):
  File "/src/flask-caching/flask_caching/__init__.py", line 679, in decorated_function
    if current_app.debug:
  File "/usr/local/lib/python3.4/site-packages/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/usr/local/lib/python3.4/site-packages/werkzeug/local.py", line 306, in _get_current_object
    return self.__local()
  File "/usr/local/lib/python3.4/site-packages/flask/globals.py", line 34, in _find_app
    raise RuntimeError('working outside of application context')
RuntimeError: working outside of application context
```
