### PR TITLE
Specify Pypi package name in ReadMe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ extension.
 Setup
 -----
 
+Installation:
+```shell
+pip install Flask-Caching
+```
+
 The Cache Extension can either be initialized directly:
 
 ```python


### PR DESCRIPTION
It's not obvious if you're unfamiliar with python import vs package naming conventions.