### PR TITLE
add request body based caching

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -419,12 +419,7 @@ class Cache(object):
 
 
             def _make_cache_key_request_body():
-                """Create keys based on request body.
-
-                Produces the same cache key regardless of argument order, e.g.,
-                both `?limit=10&offset=20` and `?offset=20&limit=10` will
-                always produce the same exact cache key.
-                """
+                """Create keys based on request body."""
 
                 # now hash the request body so it can be
                 # used as a key for cache.


### PR DESCRIPTION
This PR is a stab at #71, caching based on request body.

I implemented it because it seemed like a fairly easy thing to do and I was looking for an excuse to dig through this projects source a little bit to get a better understanding, but I would like to raise the point that this functionality is very dangerous.

> The POST method is used to submit an entity to the specified resource, often causing a change in state or side effects on the server.

> The difference between PUT and POST is that PUT is idempotent: calling it once or several times successively has the same effect (that is no side effect), where successive identical POST may have additional effects, like passing an order several times.

POST requests are typically for operations like resource creation on the server, and I worry that implementing this feature will lead some users astray, either by caching routes and thus essentially dropping requests since they never go through the server logic, or misinforming less experienced users into flawed usage of POST requests.

What do you think @sh4nks?

resolves #71 

