### PR TITLE
parameterize the hash function so alternatives can be used

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -339,6 +339,9 @@ class Cache(object):
                              were passed in a different order. See
                              _make_cache_key_query_string() for more
                              details.
+        :param hash_method: Default hashlib.md5. The hash method used to
+                            generate the keys for cached results.
+
         """
         def decorator(f):
             @functools.wraps(f)
@@ -658,7 +661,8 @@ class Cache(object):
                               cache value will be updated regardless cache
                               is expired or not. Useful for background
                               renewal of cached functions.
-
+        :param hash_method: Default hashlib.md5. The hash method used to
+                            generate the keys for cached results.
         .. versionadded:: 0.5
             params ``make_name``, ``unless``
         """

--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -28,6 +28,9 @@ __version__ = '1.4.0'
 logger = logging.getLogger(__name__)
 
 TEMPLATE_FRAGMENT_KEY_TEMPLATE = '_template_fragment_cache_%s%s'
+SUPPORTED_HASH_FUNCTIONS = [
+    hashlib.sha1, hashlib.sha224, hashlib.sha256, hashlib.sha384, hashlib.sha512, hashlib.md5
+]
 
 # Used to remove control characters and whitespace from cache keys.
 valid_chars = set(string.ascii_letters + string.digits + '_.')

--- a/flask_caching/backends/cache.py
+++ b/flask_caching/backends/cache.py
@@ -699,6 +699,8 @@ class FileSystemCache(BaseCache):
                             specified on :meth:`~BaseCache.set`. A timeout of
                             0 indicates that the cache never expires.
     :param mode: the file mode wanted for the cache files, default 0600
+    :param hash_method: Default hashlib.md5. The hash method used to
+                        generate the filename for cached results.
     """
 
     #: used for temporary files by the FileSystemCache

--- a/flask_caching/backends/cache.py
+++ b/flask_caching/backends/cache.py
@@ -61,7 +61,7 @@ import re
 import errno
 import tempfile
 import platform
-from hashlib import md5
+import hashlib
 from time import time
 try:
     import cPickle as pickle
@@ -707,11 +707,12 @@ class FileSystemCache(BaseCache):
     _fs_count_file = '__wz_cache_count'
 
     def __init__(self, cache_dir, threshold=500, default_timeout=300,
-                 mode=0o600):
+                 mode=0o600, hash_method=hashlib.md5):
         BaseCache.__init__(self, default_timeout)
         self._path = cache_dir
         self._threshold = threshold
         self._mode = mode
+        self._hash_method = hash_method
 
         try:
             os.makedirs(self._path)
@@ -783,7 +784,7 @@ class FileSystemCache(BaseCache):
     def _get_filename(self, key):
         if isinstance(key, text_type):
             key = key.encode('utf-8')  # XXX unicode review
-        hash = md5(key).hexdigest()
+        hash = self._hash_method(key).hexdigest()
         return os.path.join(self._path, hash)
 
     def get(self, key):

--- a/tests/backends/cache/test_backend_cache.py
+++ b/tests/backends/cache/test_backend_cache.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2014 by Armin Ronacher.
     :license: BSD, see LICENSE for more details.
 """
+import hashlib
 import errno
 
 import pytest
@@ -162,8 +163,12 @@ class TestSimpleCache(GenericCacheTests):
 
 class TestFileSystemCache(GenericCacheTests):
     @pytest.fixture
-    def make_cache(self, tmpdir, hash_method):
-        return lambda **kw: cache.FileSystemCache(cache_dir=str(tmpdir), hash_method=hash_method, **kw)
+    def make_cache(self, tmpdir):
+        return lambda **kw: cache.FileSystemCache(cache_dir=str(tmpdir), **kw)
+
+    def test_filesystemcache_hashes(self, make_cache, hash_method):
+        cache = make_cache(hash_method=hash_method)
+        self.test_count_file_accuracy(cache)
 
     def test_filesystemcache_prune(self, make_cache):
         THRESHOLD = 13

--- a/tests/backends/cache/test_backend_cache.py
+++ b/tests/backends/cache/test_backend_cache.py
@@ -162,8 +162,8 @@ class TestSimpleCache(GenericCacheTests):
 
 class TestFileSystemCache(GenericCacheTests):
     @pytest.fixture
-    def make_cache(self, tmpdir):
-        return lambda **kw: cache.FileSystemCache(cache_dir=str(tmpdir), **kw)
+    def make_cache(self, tmpdir, hash_method):
+        return lambda **kw: cache.FileSystemCache(cache_dir=str(tmpdir), hash_method=hash_method, **kw)
 
     def test_filesystemcache_prune(self, make_cache):
         THRESHOLD = 13

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import hashlib
 import os
 
 import flask
@@ -85,7 +86,13 @@ def app(request):
     app.config["CACHE_TYPE"] = "simple"
     return app
 
-
 @pytest.fixture
-def cache(app):
+def cache(app, hash_method):
     return fsc.Cache(app)
+
+@pytest.fixture(params=[hashlib.md5, hashlib.sha256], ids=[
+    'md5',
+    'sha256'
+])
+def hash_method(request):
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,13 +86,12 @@ def app(request):
     app.config["CACHE_TYPE"] = "simple"
     return app
 
+
 @pytest.fixture
-def cache(app, hash_method):
+def cache(app):
     return fsc.Cache(app)
 
-@pytest.fixture(params=[hashlib.md5, hashlib.sha256], ids=[
-    'md5',
-    'sha256'
-])
+@pytest.fixture(params=[method for method in fsc.SUPPORTED_HASH_FUNCTIONS], ids=[method.__name__ for method in fsc.SUPPORTED_HASH_FUNCTIONS])
 def hash_method(request):
     return request.param
+

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -23,7 +23,24 @@ def test_cache_delete(app, cache):
     assert cache.get('hi') is None
 
 
-def test_cache_cached_function(app, cache, hash_method):
+def test_cache_cached_function(app, cache):
+    with app.test_request_context():
+        @cache.cached(1, key_prefix='MyBits')
+        def get_random_bits():
+            return [random.randrange(0, 2) for i in range(50)]
+
+        my_list = get_random_bits()
+        his_list = get_random_bits()
+
+        assert my_list == his_list
+
+        time.sleep(2)
+
+        his_list = get_random_bits()
+
+        assert my_list != his_list
+
+def test_cache_accepts_multiple_ciphers(app, cache, hash_method):
     with app.test_request_context():
         @cache.cached(1, key_prefix='MyBits', hash_method=hash_method)
         def get_random_bits():

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -23,9 +23,9 @@ def test_cache_delete(app, cache):
     assert cache.get('hi') is None
 
 
-def test_cache_cached_function(app, cache):
+def test_cache_cached_function(app, cache, hash_method):
     with app.test_request_context():
-        @cache.cached(1, key_prefix='MyBits')
+        @cache.cached(1, key_prefix='MyBits', hash_method=hash_method)
         def get_random_bits():
             return [random.randrange(0, 2) for i in range(50)]
 

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -3,9 +3,9 @@ import time
 from flask import request
 
 
-def test_cached_view(app, cache):
+def test_cached_view(app, cache, hash_method):
     @app.route('/')
-    @cache.cached(2)
+    @cache.cached(2, hash_method=hash_method)
     def cached_view():
         return str(time.time())
 
@@ -26,14 +26,14 @@ def test_cached_view(app, cache):
     assert the_time != rv.data.decode('utf-8')
 
 
-def test_cached_view_unless(app, cache):
+def test_cached_view_unless(app, cache, hash_method):
     @app.route('/a')
-    @cache.cached(5, unless=lambda: True)
+    @cache.cached(5, unless=lambda: True, hash_method=hash_method)
     def non_cached_view():
         return str(time.time())
 
     @app.route('/b')
-    @cache.cached(5, unless=lambda: False)
+    @cache.cached(5, unless=lambda: False, hash_method=hash_method)
     def cached_view():
         return str(time.time())
 
@@ -56,11 +56,11 @@ def test_cached_view_unless(app, cache):
     assert the_time == rv.data.decode('utf-8')
 
 
-def test_cached_view_forced_update(app, cache):
+def test_cached_view_forced_update(app, cache, hash_method):
     forced_update = False
 
     @app.route('/a')
-    @cache.cached(5, forced_update=lambda: forced_update)
+    @cache.cached(5, forced_update=lambda: forced_update, hash_method=hash_method)
     def view():
         return str(time.time())
 
@@ -83,9 +83,9 @@ def test_cached_view_forced_update(app, cache):
     assert new_time == rv.data.decode('utf-8')
 
 
-def test_generate_cache_key_from_different_view(app, cache):
+def test_generate_cache_key_from_different_view(app, cache, hash_method):
     @app.route('/cake/<flavor>')
-    @cache.cached()
+    @cache.cached(hash_method=hash_method)
     def view_cake(flavor):
         # What's the cache key for apple cake? thanks for making me hungry
         view_cake.cake_cache_key = view_cake.make_cache_key('apple')
@@ -95,7 +95,7 @@ def test_generate_cache_key_from_different_view(app, cache):
     view_cake.cake_cache_key = ''
 
     @app.route('/pie/<flavor>')
-    @cache.cached()
+    @cache.cached(hash_method=hash_method)
     def view_pie(flavor):
         # What's the cache key for apple cake?
         view_pie.cake_cache_key = view_cake.make_cache_key('apple')
@@ -114,9 +114,9 @@ def test_generate_cache_key_from_different_view(app, cache):
 
 
 # rename/move to seperate module?
-def test_cache_key_property(app, cache):
+def test_cache_key_property(app, cache, hash_method):
     @app.route('/')
-    @cache.cached(5)
+    @cache.cached(5, hash_method=hash_method)
     def cached_view():
         return str(time.time())
 
@@ -133,9 +133,9 @@ def test_cache_key_property(app, cache):
         assert the_time == cache_data
 
 
-def test_make_cache_key_function_property(app, cache):
+def test_make_cache_key_function_property(app, cache, hash_method):
     @app.route('/<foo>/<bar>')
-    @cache.memoize(5)
+    @cache.memoize(5, hash_method=hash_method)
     def cached_view(foo, bar):
         return str(time.time())
 
@@ -156,14 +156,14 @@ def test_make_cache_key_function_property(app, cache):
     assert the_time != different_data
 
 
-def test_cache_timeout_property(app, cache):
+def test_cache_timeout_property(app, cache, hash_method):
     @app.route('/')
-    @cache.memoize(2)
+    @cache.memoize(2, hash_method=hash_method)
     def cached_view1():
         return str(time.time())
 
     @app.route('/<foo>/<bar>')
-    @cache.memoize(4)
+    @cache.memoize(4, hash_method=hash_method)
     def cached_view2(foo, bar):
         return str(time.time())
 
@@ -202,7 +202,7 @@ def test_cache_timeout_property(app, cache):
     assert time2 != tc.get('/a/b').data.decode('utf-8')
 
 
-def test_generate_cache_key_from_query_string(app, cache):
+def test_generate_cache_key_from_query_string(app, cache, hash_method):
     """Test the _make_cache_key_query_string() cache key maker.
 
     Create three requests to verify that the same query string
@@ -225,7 +225,7 @@ def test_generate_cache_key_from_query_string(app, cache):
     """
 
     @app.route('/works')
-    @cache.cached(query_string=True)
+    @cache.cached(query_string=True, hash_method=hash_method)
     def view_works():
         return str(time.time())
 
@@ -258,7 +258,7 @@ def test_generate_cache_key_from_query_string(app, cache):
     # don't yield the same cache!
     assert not third_time == second_time
 
-def test_generate_cache_key_from_query_string_repeated_paramaters(app, cache):
+def test_generate_cache_key_from_query_string_repeated_paramaters(app, cache, hash_method):
     """Test the _make_cache_key_query_string() cache key maker's support for
     repeated query paramaters
 
@@ -267,7 +267,7 @@ def test_generate_cache_key_from_query_string_repeated_paramaters(app, cache):
     """
 
     @app.route('/works')
-    @cache.cached(query_string=True)
+    @cache.cached(query_string=True, hash_method=hash_method)
     def view_works():
         flatted_values = sum(request.args.listvalues(), [])
         return str(sorted(flatted_values)) + str(time.time())

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -3,9 +3,9 @@ import time
 from flask import request
 
 
-def test_cached_view(app, cache, hash_method):
+def test_cached_view(app, cache):
     @app.route('/')
-    @cache.cached(2, hash_method=hash_method)
+    @cache.cached(2)
     def cached_view():
         return str(time.time())
 
@@ -26,14 +26,14 @@ def test_cached_view(app, cache, hash_method):
     assert the_time != rv.data.decode('utf-8')
 
 
-def test_cached_view_unless(app, cache, hash_method):
+def test_cached_view_unless(app, cache):
     @app.route('/a')
-    @cache.cached(5, unless=lambda: True, hash_method=hash_method)
+    @cache.cached(5, unless=lambda: True)
     def non_cached_view():
         return str(time.time())
 
     @app.route('/b')
-    @cache.cached(5, unless=lambda: False, hash_method=hash_method)
+    @cache.cached(5, unless=lambda: False)
     def cached_view():
         return str(time.time())
 
@@ -56,11 +56,11 @@ def test_cached_view_unless(app, cache, hash_method):
     assert the_time == rv.data.decode('utf-8')
 
 
-def test_cached_view_forced_update(app, cache, hash_method):
+def test_cached_view_forced_update(app, cache):
     forced_update = False
 
     @app.route('/a')
-    @cache.cached(5, forced_update=lambda: forced_update, hash_method=hash_method)
+    @cache.cached(5, forced_update=lambda: forced_update)
     def view():
         return str(time.time())
 
@@ -83,9 +83,9 @@ def test_cached_view_forced_update(app, cache, hash_method):
     assert new_time == rv.data.decode('utf-8')
 
 
-def test_generate_cache_key_from_different_view(app, cache, hash_method):
+def test_generate_cache_key_from_different_view(app, cache):
     @app.route('/cake/<flavor>')
-    @cache.cached(hash_method=hash_method)
+    @cache.cached()
     def view_cake(flavor):
         # What's the cache key for apple cake? thanks for making me hungry
         view_cake.cake_cache_key = view_cake.make_cache_key('apple')
@@ -95,7 +95,7 @@ def test_generate_cache_key_from_different_view(app, cache, hash_method):
     view_cake.cake_cache_key = ''
 
     @app.route('/pie/<flavor>')
-    @cache.cached(hash_method=hash_method)
+    @cache.cached()
     def view_pie(flavor):
         # What's the cache key for apple cake?
         view_pie.cake_cache_key = view_cake.make_cache_key('apple')
@@ -114,9 +114,9 @@ def test_generate_cache_key_from_different_view(app, cache, hash_method):
 
 
 # rename/move to seperate module?
-def test_cache_key_property(app, cache, hash_method):
+def test_cache_key_property(app, cache):
     @app.route('/')
-    @cache.cached(5, hash_method=hash_method)
+    @cache.cached(5)
     def cached_view():
         return str(time.time())
 
@@ -133,9 +133,9 @@ def test_cache_key_property(app, cache, hash_method):
         assert the_time == cache_data
 
 
-def test_make_cache_key_function_property(app, cache, hash_method):
+def test_make_cache_key_function_property(app, cache):
     @app.route('/<foo>/<bar>')
-    @cache.memoize(5, hash_method=hash_method)
+    @cache.memoize(5)
     def cached_view(foo, bar):
         return str(time.time())
 
@@ -156,14 +156,14 @@ def test_make_cache_key_function_property(app, cache, hash_method):
     assert the_time != different_data
 
 
-def test_cache_timeout_property(app, cache, hash_method):
+def test_cache_timeout_property(app, cache):
     @app.route('/')
-    @cache.memoize(2, hash_method=hash_method)
+    @cache.memoize(2)
     def cached_view1():
         return str(time.time())
 
     @app.route('/<foo>/<bar>')
-    @cache.memoize(4, hash_method=hash_method)
+    @cache.memoize(4)
     def cached_view2(foo, bar):
         return str(time.time())
 
@@ -202,7 +202,7 @@ def test_cache_timeout_property(app, cache, hash_method):
     assert time2 != tc.get('/a/b').data.decode('utf-8')
 
 
-def test_generate_cache_key_from_query_string(app, cache, hash_method):
+def test_generate_cache_key_from_query_string(app, cache):
     """Test the _make_cache_key_query_string() cache key maker.
 
     Create three requests to verify that the same query string
@@ -225,7 +225,7 @@ def test_generate_cache_key_from_query_string(app, cache, hash_method):
     """
 
     @app.route('/works')
-    @cache.cached(query_string=True, hash_method=hash_method)
+    @cache.cached(query_string=True)
     def view_works():
         return str(time.time())
 
@@ -258,7 +258,7 @@ def test_generate_cache_key_from_query_string(app, cache, hash_method):
     # don't yield the same cache!
     assert not third_time == second_time
 
-def test_generate_cache_key_from_query_string_repeated_paramaters(app, cache, hash_method):
+def test_generate_cache_key_from_query_string_repeated_paramaters(app, cache):
     """Test the _make_cache_key_query_string() cache key maker's support for
     repeated query paramaters
 
@@ -267,7 +267,7 @@ def test_generate_cache_key_from_query_string_repeated_paramaters(app, cache, ha
     """
 
     @app.route('/works')
-    @cache.cached(query_string=True, hash_method=hash_method)
+    @cache.cached(query_string=True)
     def view_works():
         flatted_values = sum(request.args.listvalues(), [])
         return str(sorted(flatted_values)) + str(time.time())


### PR DESCRIPTION
This PR resolves #65 by making the hashing function used a parameter in all functions/methods that used to be hard-coded to use md5.

This PR makes a change to all the tests that use affected methods to try with both md5 and sha256, but this might be overkill, tell me what you think @sh4nks and I'll take them out if you'd rather just an individual test or two to verify that multiple hash functions work. 