### PR TITLE
Don’t run cached/memoized function if the cached return value is None

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -392,8 +392,16 @@ class Cache(object):
 
                     if callable(forced_update) and forced_update() is True:
                         rv = None
+                        found = False
                     else:
                         rv = self.cache.get(cache_key)
+                        found = True
+
+                        # If the value returned by cache.get() is None, it
+                        # might be because the key is not found in the cache
+                        # or because the cached value is actually None
+                        if rv is None:
+                            found = self.cache.has(cache_key)
                 except Exception:
                     if self.app.debug:
                         raise
@@ -402,7 +410,7 @@ class Cache(object):
                     )
                     return f(*args, **kwargs)
 
-                if rv is None:
+                if not found:
                     rv = f(*args, **kwargs)
 
                     if response_filter is None or response_filter(rv):
@@ -765,8 +773,16 @@ class Cache(object):
 
                     if callable(forced_update) and forced_update() is True:
                         rv = None
+                        found = False
                     else:
                         rv = self.cache.get(cache_key)
+                        found = True
+
+                        # If the value returned by cache.get() is None, it
+                        # might be because the key is not found in the cache
+                        # or because the cached value is actually None
+                        if rv is None:
+                            found = self.cache.has(cache_key)
                 except Exception:
                     if self.app.debug:
                         raise
@@ -775,7 +791,7 @@ class Cache(object):
                     )
                     return f(*args, **kwargs)
 
-                if rv is None:
+                if not found:
                     rv = f(*args, **kwargs)
                     try:
                         self.cache.set(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -77,3 +77,27 @@ def test_cache_accepts_multiple_ciphers(app, cache, hash_method):
         his_list = get_random_bits()
 
         assert my_list != his_list
+
+
+def test_cached_none(app, cache):
+    with app.test_request_context():
+        from collections import Counter
+
+        call_counter = Counter()
+
+        @cache.cached()
+        def cache_none(param):
+            call_counter[param] += 1
+
+            return None
+
+        cache_none(1)
+
+        assert call_counter[1] == 1
+        assert cache_none(1) is None
+        assert call_counter[1] == 1
+
+        cache.clear()
+
+        cache_none(1)
+        assert call_counter[1] == 2

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -564,3 +564,32 @@ def test_memoize_when_using_variable_mix_args_unpacking(app, cache):
 
         assert big_foo(1, 2, 3, 4, x=2, y=5) != result_a
         assert big_foo(4, 7, 7, 2, x=1, y=4) != result_b
+
+
+def test_memoize_none(app, cache):
+    with app.test_request_context():
+        from collections import Counter
+
+        call_counter = Counter()
+
+        @cache.memoize()
+        def memoize_none(param):
+            call_counter[param] += 1
+
+            return None
+
+        memoize_none(1)
+
+        # The memoized function should have been called
+        assert call_counter[1] == 1
+
+        # Next time we call the function, the value should be coming from the cache…
+        assert memoize_none(1) is None
+
+        # …thus, the call counter should remain 1
+        assert call_counter[1] == 1
+
+        cache.clear()
+
+        memoize_none(1)
+        assert call_counter[1] == 2


### PR DESCRIPTION
Fixes #106