### PR TITLE
Make the forced_update of @cached and @memoize accept the same parameters as the decorated function

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -41,6 +41,15 @@ delchars = "".join(c for c in map(chr, range(256)) if c not in valid_chars)
 null_control = (dict((k, None) for k in delchars),)
 
 
+def wants_args(f):
+    """Check if the function wants any arguments
+    """
+
+    argspec = inspect.getfullargspec(f)
+
+    return bool(argspec.args or argspec.varargs or argspec.varkw)
+
+
 def get_arg_names(f):
     """Return arguments of function
 
@@ -364,7 +373,12 @@ class Cache(object):
                             args, kwargs, use_request=True
                         )
 
-                    if callable(forced_update) and forced_update() is True:
+                    if callable(forced_update) and \
+                       (
+                           forced_update(*args, **kwargs)
+                           if wants_args(forced_update)
+                           else forced_update()
+                       ) is True:
                         rv = None
                         found = False
                     else:

--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -483,6 +483,7 @@ class Cache(object):
         self,
         f,
         args=None,
+        kwargs=None,
         reset=False,
         delete=False,
         timeout=None,
@@ -508,7 +509,12 @@ class Cache(object):
         version_data_list = list(self.cache.get_many(*fetch_keys))
         dirty = False
 
-        if callable(forced_update) and forced_update() is True:
+        if callable(forced_update) and \
+           (
+               forced_update(*(args or ()), **(kwargs or {}))
+               if wants_args(forced_update)
+               else forced_update()
+           ) is True:
             # Mark key as dirty to update its TTL
             dirty = True
 
@@ -746,7 +752,12 @@ class Cache(object):
                         f, *args, **kwargs
                     )
 
-                    if callable(forced_update) and forced_update() is True:
+                    if callable(forced_update) and \
+                       (
+                           forced_update(*args, **kwargs)
+                           if wants_args(forced_update)
+                           else forced_update()
+                       ) is True:
                         rv = None
                         found = False
                     else:


### PR DESCRIPTION
Fixes #112 