### PR TITLE
Remove the -dev suffix from Python 3.7 in Tox and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
+os: linux
+dist: xenial
 sudo: false
 language: python
 python:
  - "2.7"
  - "3.5"
  - "3.6"
- - "3.7-dev"
+ - "3.7"
  - "pypy"
  - "pypy3"
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36, py37-dev
+envlist = py27, py35, py36, py37
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.7 is released as stable for a while now, there’s no need to have it pinned to a dev version.