### PR TITLE
Allow to pass arguments to pytest via tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ envlist = py35, py36, py37
 deps =
     -r{toxinidir}/requirements.txt
     pytest-xprocess
-commands = pytest
+commands = pytest {posargs}


### PR DESCRIPTION
This is useful run run only a few tests.