### PR TITLE
add unlink in RedisCache when redis-py >= 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ script: py.test
 after_success:
   - coveralls
 cache: pip
+services:
+ - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,3 @@ script: py.test
 after_success:
   - coveralls
 cache: pip
-services:
- - redis-server

--- a/flask_caching/backends/rediscache.py
+++ b/flask_caching/backends/rediscache.py
@@ -57,7 +57,6 @@ class RedisCache(BaseCache):
             client = host
 
         self._write_client = self._read_clients = client
-        self._version = redis.__version__
         self.key_prefix = key_prefix or ""
 
     def _normalize_timeout(self, timeout):
@@ -166,7 +165,11 @@ class RedisCache(BaseCache):
         return self._write_client.decr(name=self.key_prefix + key, amount=delta)
 
     def unlink(self, *keys):
-        if self._version >= "3.0.0":
+        """
+        when redis-py >= 3.0.0 and redis > 4, support this operation
+        """
+        unlink = getattr(self._write_client, "unlink", None)
+        if unlink is not None and callable(unlink):
             return self._write_client.unlink(*keys)
         raise ValueError(
             "Current Redis Version doesn't support this operation, "

--- a/flask_caching/backends/rediscache.py
+++ b/flask_caching/backends/rediscache.py
@@ -57,6 +57,7 @@ class RedisCache(BaseCache):
             client = host
 
         self._write_client = self._read_clients = client
+        self._version = redis.__version__
         self.key_prefix = key_prefix or ""
 
     def _normalize_timeout(self, timeout):
@@ -163,6 +164,14 @@ class RedisCache(BaseCache):
 
     def dec(self, key, delta=1):
         return self._write_client.decr(name=self.key_prefix + key, amount=delta)
+
+    def unlink(self, *keys):
+        if self._version >= "3.0.0":
+            return self._write_client.unlink(*keys)
+        raise ValueError(
+            "Current Redis Version doesn't support this operation, "
+            "please upgrade redis-py to 3.0.0 at least"
+        )
 
 
 class RedisSentinelCache(RedisCache):

--- a/flask_caching/backends/rediscache.py
+++ b/flask_caching/backends/rediscache.py
@@ -168,6 +168,10 @@ class RedisCache(BaseCache):
         """
         when redis-py >= 3.0.0 and redis > 4, support this operation
         """
+        if not keys:
+            return
+        if self.key_prefix:
+            keys = [self.key_prefix + key for key in keys]
         unlink = getattr(self._write_client, "unlink", None)
         if unlink is not None and callable(unlink):
             return self._write_client.unlink(*keys)

--- a/tests/test_backend_cache.py
+++ b/tests/test_backend_cache.py
@@ -243,6 +243,11 @@ class TestRedisCache(GenericCacheTests):
             == "RedisCache host parameter may not be None"
         )
 
+    def test_unlink_keys(self, c):
+        c._write_client.set(c.key_prefix + "biggerkey", [0] * 100)
+        c._write_client.unlink(c.key_prefix + "biggerkey")
+        assert c.get("bigger_key") is None
+
 
 class TestMemcachedCache(GenericCacheTests):
     _can_use_fast_sleep = False

--- a/tests/test_backend_cache.py
+++ b/tests/test_backend_cache.py
@@ -244,7 +244,7 @@ class TestRedisCache(GenericCacheTests):
         )
 
     def test_unlink_keys(self, c):
-        c._write_client.set(c.key_prefix + "biggerkey", [0] * 100)
+        c._write_client.set(c.key_prefix + "biggerkey", "test" * 100)
         c._write_client.unlink(c.key_prefix + "biggerkey")
         assert c.get("bigger_key") is None
 

--- a/tests/test_backend_cache.py
+++ b/tests/test_backend_cache.py
@@ -243,7 +243,7 @@ class TestRedisCache(GenericCacheTests):
             == "RedisCache host parameter may not be None"
         )
 
-    def test_unlink_keys(self, c):
+    def test_unlink(self, c):
         c._write_client.set(c.key_prefix + "biggerkey", "test" * 100)
         c._write_client.unlink(c.key_prefix + "biggerkey")
         assert c.get("bigger_key") is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -182,18 +182,3 @@ def test_cache_forced_update_params(app, cache):
         # this time the forced_update should have returned True, so
         # cached_function should have been called again
         assert cached_call_counter[1] == 2
-
-
-def test_unlink_keys(app, cache):
-    config = {
-        "CACHE_TYPE": "redis",
-        "CACHE_REDIS_URL": "redis://localhost:6379/2",
-    }
-    cache.init_app(app, config=config)
-    cache.add("biggerkey", [0] * 100)
-    try:
-        cache.unlink("biggerkey")
-    except ValueError:
-        return
-    else:
-        assert cache.get("bigger_key") is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -182,3 +182,18 @@ def test_cache_forced_update_params(app, cache):
         # this time the forced_update should have returned True, so
         # cached_function should have been called again
         assert cached_call_counter[1] == 2
+
+
+def test_unlink_keys(app, cache):
+    config = {
+        "CACHE_TYPE": "redis",
+        "CACHE_REDIS_URL": "redis://localhost:6379/2",
+    }
+    cache.init_app(app, config=config)
+    cache.add("biggerkey", [0] * 100)
+    try:
+        cache.unlink("biggerkey")
+    except ValueError:
+        return
+    else:
+        assert cache.get("bigger_key") is None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -41,6 +41,14 @@ def test_cache_delete_many_ignored(app):
     assert cache.get("hi") is None
 
 
+def test_cache_unlink(app):
+    cache = Cache(config={"CACHE_TYPE": "redis"})
+    cache.init_app(app)
+    cache.set("biggerkey", "test" * 100)
+    cache.unlink("biggerkey")
+    assert cache.get("bigger_key") is None
+
+
 def test_cache_cached_function(app, cache):
     with app.test_request_context():
 


### PR DESCRIPTION
When the deleted key is large,  the `unlink` is better than the `delete`.