### PR TITLE
cache_none option for memoize to deal with concurrency problem

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -753,6 +753,10 @@ class Cache(object):
                               renewal of cached functions.
         :param hash_method: Default hashlib.md5. The hash method used to
                             generate the keys for cached results.
+        :param cache_none: Default False. If set to True, add a key exists
+                           check when cache.get returns None. This will likely
+                           lead to wrongly returned None values in concurrent
+                           situations and is not recommended to use.
 
         .. versionadded:: 0.5
             params ``make_name``, ``unless``

--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -695,7 +695,7 @@ class Cache(object):
         unless=None,
         forced_update=None,
         hash_method=hashlib.md5,
-        returns_none=True,
+        cache_none=False,
     ):
         """Use this to cache the result of a function, taking its arguments
         into account in the cache key.
@@ -789,13 +789,13 @@ class Cache(object):
                         # might be because the key is not found in the cache
                         # or because the cached value is actually None
                         if rv is None:
-                            # If we're sure the function never returns None
-                            # (returns_none=True), don't bother checking for
-                            # key existence as it can lead to false positives
-                            # if a concurrent call already cached
-                            # the key between steps. This would cause us to
+                            # If we're sure we don't need to cache None values
+                            # (cache_none=False), don't bother checking for
+                            # key existence, as it can lead to false positives
+                            # if a concurrent call already cached the
+                            # key between steps. This would cause us to
                             # return None when we shouldn't
-                            if not returns_none:
+                            if not cache_none:
                                 found = False
                             else:
                                 found = self.cache.has(cache_key)

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -656,7 +656,7 @@ def test_memoize_none(app, cache):
 
         call_counter = Counter()
 
-        @cache.memoize()
+        @cache.memoize(cache_none=True)
         def memoize_none(param):
             call_counter[param] += 1
 
@@ -680,7 +680,7 @@ def test_memoize_none(app, cache):
 
 
 def test_memoize_never_accept_none(app, cache):
-    """Asserting that when returns_none is True, we always
+    """Asserting that when cache_none is False, we always
        assume a None value returned from .get() means the key is not found
     """
     with app.test_request_context():
@@ -688,7 +688,7 @@ def test_memoize_never_accept_none(app, cache):
 
         call_counter = Counter()
 
-        @cache.memoize(returns_none=False)
+        @cache.memoize()
         def memoize_none(param):
             call_counter[param] += 1
 


### PR DESCRIPTION
Fixes #135 by allowing the user to specify if their function never returns None.  If so, we can safely assume a None returned from cache.get() means the key does not exist.