### PR TITLE
use the `_pickle` to replace `cPickle` in python3

### DIFF
--- a/flask_caching/backends/filesystem.py
+++ b/flask_caching/backends/filesystem.py
@@ -180,7 +180,8 @@ class FileSystemCache(BaseCache):
             )
             with os.fdopen(fd, "wb") as f:
                 pickle.dump(timeout, f, 1)
-                pickle.dump(value, f, pickle.HIGHEST_PROTOCOL)
+                # 4 was the highest protocol
+                pickle.dump(value, f, 4)
             rename(tmp, filename)
             os.chmod(filename, self._mode)
         except (IOError, OSError):

--- a/flask_caching/backends/filesystem.py
+++ b/flask_caching/backends/filesystem.py
@@ -13,16 +13,12 @@ import errno
 import hashlib
 import os
 import tempfile
+import _pickle as pickle
 from time import time
 
 from werkzeug.posixemulation import rename
 
 from flask_caching.backends.base import BaseCache
-
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
 
 
 class FileSystemCache(BaseCache):

--- a/flask_caching/backends/filesystem.py
+++ b/flask_caching/backends/filesystem.py
@@ -180,8 +180,7 @@ class FileSystemCache(BaseCache):
             )
             with os.fdopen(fd, "wb") as f:
                 pickle.dump(timeout, f, 1)
-                # 4 was the highest protocol
-                pickle.dump(value, f, 4)
+                pickle.dump(value, f, 4)  # 4 was the highest protocol
             rename(tmp, filename)
             os.chmod(filename, self._mode)
         except (IOError, OSError):

--- a/flask_caching/backends/memcache.py
+++ b/flask_caching/backends/memcache.py
@@ -15,10 +15,7 @@ from time import time
 
 from flask_caching.backends.base import BaseCache, iteritems_wrapper
 
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
+import _pickle as pickle
 
 
 _test_memcached_key = re.compile(r"[^\x00-\x21\xff]{1,250}$").match

--- a/flask_caching/backends/rediscache.py
+++ b/flask_caching/backends/rediscache.py
@@ -12,7 +12,7 @@
 from flask_caching.backends.base import BaseCache, iteritems_wrapper
 
 try:
-    import cPickle as pickle
+    import _pickle as pickle
 except ImportError:  # pragma: no cover
     import pickle
 

--- a/flask_caching/backends/rediscache.py
+++ b/flask_caching/backends/rediscache.py
@@ -11,10 +11,7 @@
 """
 from flask_caching.backends.base import BaseCache, iteritems_wrapper
 
-try:
-    import _pickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
+import _pickle as pickle
 
 
 class RedisCache(BaseCache):

--- a/flask_caching/backends/simple.py
+++ b/flask_caching/backends/simple.py
@@ -77,8 +77,7 @@ class SimpleCache(BaseCache):
     def add(self, key, value, timeout=None):
         expires = self._normalize_timeout(timeout)
         self._prune()
-        # 4 was the highest protocol
-        item = (expires, pickle.dumps(value, 4))
+        item = (expires, pickle.dumps(value, 4))  # 4 was the highest protocol
         if key in self._cache:
             return False
         self._cache.setdefault(key, item)

--- a/flask_caching/backends/simple.py
+++ b/flask_caching/backends/simple.py
@@ -9,14 +9,11 @@
     :copyright: (c) 2010 by Thadeus Burgess.
     :license: BSD, see LICENSE for more details.
 """
+import _pickle as pickle
+
 from time import time
 
 from flask_caching.backends.base import BaseCache
-
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
 
 
 class SimpleCache(BaseCache):

--- a/flask_caching/backends/simple.py
+++ b/flask_caching/backends/simple.py
@@ -70,14 +70,15 @@ class SimpleCache(BaseCache):
         self._prune()
         self._cache[key] = (
             expires,
-            pickle.dumps(value, pickle.HIGHEST_PROTOCOL),
+            pickle.dumps(value, 4),  # 4 was the highest protocol
         )
         return True
 
     def add(self, key, value, timeout=None):
         expires = self._normalize_timeout(timeout)
         self._prune()
-        item = (expires, pickle.dumps(value, pickle.HIGHEST_PROTOCOL))
+        # 4 was the highest protocol
+        item = (expires, pickle.dumps(value, 4))
         if key in self._cache:
             return False
         self._cache.setdefault(key, item)

--- a/flask_caching/backends/uwsgicache.py
+++ b/flask_caching/backends/uwsgicache.py
@@ -10,13 +10,9 @@
     :license: BSD, see LICENSE for more details.
 """
 import platform
+import _pickle as pickle
 
 from flask_caching.backends.base import BaseCache
-
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
 
 
 class UWSGICache(BaseCache):


### PR DESCRIPTION
Use the _pickle to replace the cPickle.
And the pickle. HIGHEST_PROTOCOL was removed,  so use the magic num `4` to replace it.

-------------------------------------

The pypy3 download url  was 404. 
Travis was not passed.

Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/pypy3.tar.bz2
0.10s$ curl -sSf --retry 5 -o pypy3.tar.bz2 ${archive_url}
curl: (22) The requested URL returned error: 404 
Unable to download pypy3 archive. The archive may not exist. Please consider a different version.