### PR TITLE
use the _pickle to replace the cPickle in python3

### DIFF
--- a/flask_caching/backends/filesystem.py
+++ b/flask_caching/backends/filesystem.py
@@ -13,16 +13,12 @@ import errno
 import hashlib
 import os
 import tempfile
+import _pickle as pickle
 from time import time
 
 from werkzeug.posixemulation import rename
 
 from flask_caching.backends.base import BaseCache
-
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
 
 
 class FileSystemCache(BaseCache):
@@ -184,7 +180,7 @@ class FileSystemCache(BaseCache):
             )
             with os.fdopen(fd, "wb") as f:
                 pickle.dump(timeout, f, 1)
-                pickle.dump(value, f, pickle.HIGHEST_PROTOCOL)
+                pickle.dump(value, f, 4)  # 4 was the highest protocol
             rename(tmp, filename)
             os.chmod(filename, self._mode)
         except (IOError, OSError):

--- a/flask_caching/backends/memcache.py
+++ b/flask_caching/backends/memcache.py
@@ -15,10 +15,7 @@ from time import time
 
 from flask_caching.backends.base import BaseCache, iteritems_wrapper
 
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
+import _pickle as pickle
 
 
 _test_memcached_key = re.compile(r"[^\x00-\x21\xff]{1,250}$").match

--- a/flask_caching/backends/rediscache.py
+++ b/flask_caching/backends/rediscache.py
@@ -11,10 +11,7 @@
 """
 from flask_caching.backends.base import BaseCache, iteritems_wrapper
 
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
+import _pickle as pickle
 
 
 class RedisCache(BaseCache):

--- a/flask_caching/backends/simple.py
+++ b/flask_caching/backends/simple.py
@@ -9,14 +9,11 @@
     :copyright: (c) 2010 by Thadeus Burgess.
     :license: BSD, see LICENSE for more details.
 """
+import _pickle as pickle
+
 from time import time
 
 from flask_caching.backends.base import BaseCache
-
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
 
 
 class SimpleCache(BaseCache):
@@ -73,14 +70,14 @@ class SimpleCache(BaseCache):
         self._prune()
         self._cache[key] = (
             expires,
-            pickle.dumps(value, pickle.HIGHEST_PROTOCOL),
+            pickle.dumps(value, 4),  # 4 was the highest protocol
         )
         return True
 
     def add(self, key, value, timeout=None):
         expires = self._normalize_timeout(timeout)
         self._prune()
-        item = (expires, pickle.dumps(value, pickle.HIGHEST_PROTOCOL))
+        item = (expires, pickle.dumps(value, 4))  # 4 was the highest protocol
         if key in self._cache:
             return False
         self._cache.setdefault(key, item)

--- a/flask_caching/backends/uwsgicache.py
+++ b/flask_caching/backends/uwsgicache.py
@@ -10,13 +10,9 @@
     :license: BSD, see LICENSE for more details.
 """
 import platform
+import _pickle as pickle
 
 from flask_caching.backends.base import BaseCache
-
-try:
-    import cPickle as pickle
-except ImportError:  # pragma: no cover
-    import pickle
 
 
 class UWSGICache(BaseCache):

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -8,15 +8,16 @@ def test_pickle_highest_protocol():
     else:
         level = 5
     # test wrong protocol level
+    low_level = level - 1
     try:
         _pickle.dumps({"a": 1}, level)
     except ValueError as e:
-        assert str(e) == f"pickle protocol must be <= {level - 1}"
+        assert str(e) == "pickle protocol must be <= {}".format(low_level)
     else:
         assert 1 == 2
 
     try:
-        _pickle.dumps({"a": 1}, level - 1)
+        _pickle.dumps({"a": 1}, low_level)
         e = None
     except ValueError as e:
         e = str(e)

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,19 @@
+import _pickle
+
+
+def test_pickle_highest_protocol():
+    # test wrong protocol level
+    try:
+        _pickle.dumps({"a": 1}, 5)
+    except ValueError as e:
+        assert str(e) == "pickle protocol must be <= 4"
+    else:
+        assert 1 == 2
+
+    try:
+        _pickle.dumps({"a": 1}, 4)
+        e = None
+    except ValueError as e:
+        e = str(e)
+    else:
+        assert e is None

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,17 +1,22 @@
+import sys
 import _pickle
 
 
 def test_pickle_highest_protocol():
+    if sys.version_info >= (3, 8):
+        level = 6
+    else:
+        level = 5
     # test wrong protocol level
     try:
-        _pickle.dumps({"a": 1}, 5)
+        _pickle.dumps({"a": 1}, level)
     except ValueError as e:
-        assert str(e) == "pickle protocol must be <= 4"
+        assert str(e) == f"pickle protocol must be <= {level - 1}"
     else:
         assert 1 == 2
 
     try:
-        _pickle.dumps({"a": 1}, 4)
+        _pickle.dumps({"a": 1}, level - 1)
         e = None
     except ValueError as e:
         e = str(e)


### PR DESCRIPTION
Use the _pickle to replace the cPickle.
And the `pickle.HIGHEST_PROTOCOL` has been removed,  so use the magic number `4` to replace it.

-------------------------------------

The pypy3 download url  was 404. 
Travis was not passed.

Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/18.04/x86_64/pypy3.tar.bz2
0.10s$ curl -sSf --retry 5 -o pypy3.tar.bz2 ${archive_url}
curl: (22) The requested URL returned error: 404 
Unable to download pypy3 archive. The archive may not exist. Please consider a different version.