### PR TITLE
Bugfix: pylibmc expect time as delta time

### DIFF
--- a/flask_caching/backends/memcache.py
+++ b/flask_caching/backends/memcache.py
@@ -86,6 +86,14 @@ class MemcachedCache(BaseCache):
         if timeout > 0:
             # NOTE: pylibmc expect the timeout as delta time up to
             # 2592000 seconds (30 days)
+            if not hasattr(self, 'mc_library'):
+                try:
+                    import pylibmc
+                except ImportError:
+                    self.mc_library = None
+                else:
+                    self.mc_library = 'pylibmc'
+
             if self.mc_library != 'pylibmc':
                 timeout = int(time()) + timeout
             elif timeout > 2592000:

--- a/flask_caching/backends/memcache.py
+++ b/flask_caching/backends/memcache.py
@@ -86,13 +86,7 @@ class MemcachedCache(BaseCache):
         if timeout > 0:
             # NOTE: pylibmc expect the timeout as delta time up to
             # 2592000 seconds (30 days)
-            try:
-                import pylibmc
-                using_pylibmc = True
-            except ImportError:
-                using_pylibmc = False
-
-            if not using_pylibmc:
+            if self.mc_library != 'pylibmc':
                 timeout = int(time()) + timeout
             elif timeout > 2592000:
                 timeout = 0
@@ -193,6 +187,7 @@ class MemcachedCache(BaseCache):
         except ImportError:
             pass
         else:
+            self.mc_library = 'pylibmc'
             return pylibmc.Client(servers)
 
         try:
@@ -200,6 +195,7 @@ class MemcachedCache(BaseCache):
         except ImportError:
             pass
         else:
+            self.mc_library = 'google.appengine.api'
             return memcache.Client()
 
         try:
@@ -207,6 +203,7 @@ class MemcachedCache(BaseCache):
         except ImportError:
             pass
         else:
+            self.mc_library = 'memcache'
             return memcache.Client(servers)
 
         try:
@@ -214,6 +211,7 @@ class MemcachedCache(BaseCache):
         except ImportError:
             pass
         else:
+            self.mc_library = 'libmc'
             return libmc.Client(servers)
 
 

--- a/tests/test_backend_cache.py
+++ b/tests/test_backend_cache.py
@@ -276,6 +276,12 @@ class TestMemcachedCache(GenericCacheTests):
         c.set("foo", "bar", epoch + 100)
         assert c.get("foo") == "bar"
 
+    def test_timeouts(self, c):
+        c.set("foo", "bar", 1)
+        assert c.get("foo") == "bar"
+        time.sleep(1)
+        assert c.has("foo") is False
+
 
 class TestUWSGICache(GenericCacheTests):
     _can_use_fast_sleep = False


### PR DESCRIPTION
Pylibmc expect the timeout to be provided as "number of seconds until the key expire", see http://sendapatch.se/projects/pylibmc/reference.html#pylibmc.Client.set

See more at https://github.com/sh4nks/flask-caching/issues/152