### PR TITLE
Function source code hashing when generating cache key

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -342,6 +342,14 @@ The following configuration values exist for Flask-Caching:
                                 This makes it possible to use the same
                                 memcached server for different apps.
                                 Used only for RedisCache and MemcachedCache
+``CACHE_SOURCE_CHECK``          The default condition applied to function
+                                decorators which controls if the source code of
+                                the function should be included when forming the
+                                hash which is used as the cache key. This
+                                ensures that if the source code changes, the
+                                cached value will not be returned when the new
+                                function is called even if the arguments are the
+                                same. Defaults to ``False``.
 ``CACHE_UWSGI_NAME``            The name of the uwsgi caching instance to
                                 connect to, for example: mycache@localhost:3031,
                                 defaults to an empty string, which means uWSGI

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -88,6 +88,62 @@ def test_cache_cached_function(app, cache):
         assert my_list != his_list
 
 
+def test_cache_cached_function_with_source_check_enabled(app, cache):
+    with app.test_request_context():
+
+        @cache.cached(key_prefix="MyBits", source_check=True)
+        def get_random_bits():
+            return [random.randrange(0, 2) for i in range(50)]
+
+        first_attempt = get_random_bits()
+        second_attempt = get_random_bits()
+
+        assert second_attempt == first_attempt
+
+        #... change the source  to see if the return value changes when called
+        @cache.cached(key_prefix="MyBits", source_check=True)
+        def get_random_bits():
+            return {"val": [random.randrange(0, 2) for i in range(50)]}
+
+        third_attempt = get_random_bits()
+
+        assert third_attempt != first_attempt
+        # We changed the return data type so we do a check to be sure
+        assert isinstance(third_attempt, dict)
+
+        #... change the source back to what it was original and the data should
+        # be the same
+        @cache.cached(key_prefix="MyBits", source_check=True)
+        def get_random_bits():
+            return [random.randrange(0, 2) for i in range(50)]
+
+        forth_attempt = get_random_bits()
+
+        assert forth_attempt == first_attempt
+
+
+def test_cache_cached_function_with_source_check_disabled(app, cache):
+    with app.test_request_context():
+
+        @cache.cached(key_prefix="MyBits", source_check=False)
+        def get_random_bits():
+            return [random.randrange(0, 2) for i in range(50)]
+
+        first_attempt = get_random_bits()
+        second_attempt = get_random_bits()
+
+        assert second_attempt == first_attempt
+
+        #... change the source  to see if the return value changes when called
+        @cache.cached(key_prefix="MyBits", source_check=False)
+        def get_random_bits():
+            return {"val": [random.randrange(0, 2) for i in range(50)]}
+
+        third_attempt = get_random_bits()
+
+        assert third_attempt == first_attempt
+
+
 def test_cache_accepts_multiple_ciphers(app, cache, hash_method):
     with app.test_request_context():
 

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -710,3 +710,53 @@ def test_memoize_never_accept_none(app, cache):
 
         memoize_none(1)
         assert call_counter[1] == 3
+
+
+def test_memoize_with_source_check_enabled(app, cache):
+    with app.test_request_context():
+        @cache.memoize(source_check=True)
+        def big_foo(a, b):
+            return str(time.time())
+
+        first_try = big_foo(5, 2)
+
+        second_try = big_foo(5, 2)
+
+        assert second_try == first_try
+
+        @cache.memoize(source_check=True)
+        def big_foo(a, b):
+            return (str(time.time()))
+
+        third_try = big_foo(5, 2)
+
+        assert third_try[0] != first_try
+
+        @cache.memoize(source_check=True)
+        def big_foo(a, b):
+            return str(time.time())
+
+        forth_try = big_foo(5, 2)
+
+        assert forth_try == first_try
+
+
+def test_memoize_with_source_check_disabled(app, cache):
+    with app.test_request_context():
+        @cache.memoize(source_check=False)
+        def big_foo(a, b):
+            return str(time.time())
+
+        first_try = big_foo(5, 2)
+
+        second_try = big_foo(5, 2)
+
+        assert second_try == first_try
+
+        @cache.memoize(source_check=False)
+        def big_foo(a, b):
+            return (time.time())
+
+        third_try = big_foo(5, 2)
+
+        assert third_try == first_try

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -332,3 +332,124 @@ def test_generate_cache_key_from_query_string_repeated_paramaters(app, cache):
     # ... making sure that different query parameter values
     # don't yield the same cache!
     assert not third_time == second_time
+
+
+def test_cache_with_query_string_and_source_check_enabled(app, cache):
+    """Test the _make_cache_key_query_string() cache key maker with
+    source_check set to True to include the view's function's source code as
+    part of the cache hash key.
+    """
+
+    @cache.cached(query_string=True, source_check=True)
+    def view_works():
+        return str(time.time())
+
+    app.add_url_rule('/works', 'works', view_works)
+
+    tc = app.test_client()
+
+    # Make our first query...
+    first_response = tc.get(
+        '/works?mock=true&offset=20&limit=15'
+    )
+    first_time = first_response.get_data(as_text=True)
+
+    # Make our second query...
+    second_response = tc.get(
+        '/works?mock=true&offset=20&limit=15'
+    )
+    second_time = second_response.get_data(as_text=True)
+
+    # The cache should yield the same data first and second time
+    assert first_time == second_time
+
+    # Change the source of the function attached to the view
+    @cache.cached(query_string=True, source_check=True)
+    def view_works():
+        return (str(time.time()))
+
+    #... and we overide the function attached to the view
+    app.view_functions['works'] = view_works
+
+    tc = app.test_client()
+
+    # Make the second query...
+    third_response = tc.get(
+        '/works?mock=true&offset=20&limit=15'
+    )
+    third_time = third_response.get_data(as_text=True)
+
+    # Now make sure the time for the first and third
+    # responses are not the same i.e. cached is not used!
+    assert third_time[0] != first_time
+
+    # Change the source of the function to what it was originally
+    @cache.cached(query_string=True, source_check=True)
+    def view_works():
+        return str(time.time())
+
+    app.view_functions['works'] = view_works
+
+    tc = app.test_client()
+
+    # Last/third query with different parameters/values should
+    # produce a different time.
+    forth_response = tc.get(
+        '/works?mock=true&offset=20&limit=15'
+    )
+    forth_time = forth_response.get_data(as_text=True)
+
+    # ... making sure that the first value and the forth value are the same
+    # since the source is the same
+    assert forth_time == first_time
+
+
+def test_cache_with_query_string_and_source_check_disabled(app, cache):
+    """Test the _make_cache_key_query_string() cache key maker with
+    source_check set to False to exclude the view's function's source code as
+    part of the cache hash key and to see if changing the source changes the
+    data.
+    """
+
+    @cache.cached(query_string=True, source_check=False)
+    def view_works():
+        return str(time.time())
+
+    app.add_url_rule('/works', 'works', view_works)
+
+    tc = app.test_client()
+
+    # Make our first query...
+    first_response = tc.get(
+        '/works?mock=true&offset=20&limit=15'
+    )
+    first_time = first_response.get_data(as_text=True)
+
+    # Make our second query...
+    second_response = tc.get(
+        '/works?mock=true&offset=20&limit=15'
+    )
+    second_time = second_response.get_data(as_text=True)
+
+    # The cache should yield the same data first and second time
+    assert first_time == second_time
+
+    # Change the source of the function attached to the view
+    @cache.cached(query_string=True, source_check=False)
+    def view_works():
+        return (str(time.time()))
+
+    #... and we overide the function attached to the view
+    app.view_functions['works'] = view_works
+
+    tc = app.test_client()
+
+    # Make the second query...
+    third_response = tc.get(
+        '/works?mock=true&offset=20&limit=15'
+    )
+    third_time = third_response.get_data(as_text=True)
+
+    # Now make sure the time for the first and third responses are the same
+    # i.e. cached is used since cache will not check for source changes!
+    assert third_time == first_time


### PR DESCRIPTION
Adding source_check option to Cache.cached to have it include the function's source code when forming the hash key to store along with the cached data.

Adding source check functionality to memoize.