### PR TITLE
add a `make_cache_key` parameter

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -447,7 +447,7 @@ class Cache(object):
                             )
                 return rv
 
-            def make_cache_key(*args, **kwargs):
+            def make_cache_key(*args, use_request=False, **kwargs):
                 # Convert non-keyword arguments (which is the way
                 # `make_cache_key` expects them) to keyword arguments
                 # (the way `url_for` expects them)
@@ -456,7 +456,7 @@ class Cache(object):
                 for arg_name, arg in zip(argspec_args, args):
                     kwargs[arg_name] = arg
 
-                return _make_cache_key(args, kwargs, use_request=False)
+                return _make_cache_key(args, kwargs, use_request=use_request)
 
             def _make_cache_key_query_string():
                 """Create consistent keys for query string arguments.

--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -333,6 +333,8 @@ class Cache(object):
                 **make_cache_key**
                     A function used in generating the cache_key used.
 
+                    readable and writable
+
         :param timeout: Default None. If set to an integer, will cache for that
                         amount of time. Unit of time is in seconds.
 
@@ -390,12 +392,7 @@ class Cache(object):
                     return f(*args, **kwargs)
 
                 try:
-                    if query_string:
-                        cache_key = _make_cache_key_query_string()
-                    else:
-                        cache_key = _make_cache_key(
-                            args, kwargs, use_request=True
-                        )
+                    cache_key = decorated_function.make_cache_key(args, kwargs, use_request=True)
 
                     if (
                         callable(forced_update)
@@ -487,17 +484,20 @@ class Cache(object):
                 return cache_key
 
             def _make_cache_key(args, kwargs, use_request):
-                if callable(key_prefix):
-                    cache_key = key_prefix()
-                elif "%s" in key_prefix:
-                    if use_request:
-                        cache_key = key_prefix % request.path
-                    else:
-                        cache_key = key_prefix % url_for(f.__name__, **kwargs)
+                if query_string:
+                    return _make_cache_key_query_string()
                 else:
-                    cache_key = key_prefix
+                    if callable(key_prefix):
+                        cache_key = key_prefix()
+                    elif "%s" in key_prefix:
+                        if use_request:
+                            cache_key = key_prefix % request.path
+                        else:
+                            cache_key = key_prefix % url_for(f.__name__, **kwargs)
+                    else:
+                        cache_key = key_prefix
 
-                return cache_key
+                    return cache_key
 
             decorated_function.uncached = f
             decorated_function.cache_timeout = timeout

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -332,3 +332,61 @@ def test_generate_cache_key_from_query_string_repeated_paramaters(app, cache):
     # ... making sure that different query parameter values
     # don't yield the same cache!
     assert not third_time == second_time
+
+
+def test_generate_cache_key_from_request_body(app, cache):
+    """Test a user supplied cache key maker.
+    Create three requests to verify that the same request body
+    always reference the same cache
+    Also test to make sure that the same cache isn't being used for
+    any/all query string parameters.
+    Caching functionality is verified by a `@cached` route `/works` which
+    produces a time in its response. The time in the response can verify that
+    two requests with the same request body produce responses with the same time.
+    """
+
+    def _make_cache_key_request_body():
+        """Create keys based on request body."""
+        # now hash the request body so it can be
+        # used as a key for cache.
+        request_body = request.get_data(as_text=False)
+        hashed_body = str(hashlib.md5(request_body).hexdigest())
+        cache_key = request.path + hashed_body
+        return cache_key
+
+    cache_decorator = cache.cached()
+    cache_decorator.make_cache_key = _make_cache_key_request_body
+
+    @app.route('/works', methods=['POST'])
+    @cache_decorator
+    def view_works():
+        return str(time.time()) + request.get_data().decode()
+
+    tc = app.test_client()
+
+    # Make our request...
+    first_response = tc.post(
+        '/works', data=dict(mock=True, value=1, test=2)
+    )
+    first_time = first_response.get_data(as_text=True)
+
+    # Make the request...
+    second_response = tc.post(
+        '/works', data=dict(mock=True, value=1, test=2)
+    )
+    second_time = second_response.get_data(as_text=True)
+
+    # Now make sure the time for the first and second
+    # requests are the same!
+    assert second_time == first_time
+
+    # Last/third request with different body should
+    # produce a different time.
+    third_response = tc.get(
+        '/v1/works', data=dict(mock=True, value=2, test=3)
+    )
+    third_time = third_response.get_data(as_text=True)
+
+    # ... making sure that different request bodies
+    # don't yield the same cache!
+    assert not third_time == second_time


### PR DESCRIPTION
This PR is essentially a more considered version of #76 

After the additional discussion with @bzed I changed my stance on the functionality, but actually even further it seemed like what the library actually needed was a way to allow the consumer complete control over the cache key generation if they so wished.

I have added a `make_cache_key` parameter to the `cached` decorator for this purpose.

This should allow for use cases such as #71, an example of which is in the test added in this PR
