### PR TITLE
docs: Fix simple typo, occured -> occurred

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -328,7 +328,7 @@ The following configuration values exist for Flask-Caching:
 ``CACHE_DEFAULT_TIMEOUT``       The default timeout that is used if no
                                 timeout is specified. Unit of time is
                                 seconds.
-``CACHE_IGNORE_ERRORS``         If set to any errors that occured during the
+``CACHE_IGNORE_ERRORS``         If set to any errors that occurred during the
                                 deletion process will be ignored. However, if
                                 it is set to ``False`` it will stop on the
                                 first error. This option is only relevant for

--- a/flask_caching/backends/filesystem.py
+++ b/flask_caching/backends/filesystem.py
@@ -43,7 +43,7 @@ class FileSystemCache(BaseCache):
     :param hash_method: Default hashlib.md5. The hash method used to
                         generate the filename for cached results.
     :param ignore_errors: If set to ``True`` the :meth:`~BaseCache.delete_many`
-                          method will ignore any errors that occured during the
+                          method will ignore any errors that occurred during the
                           deletion process. However, if it is set to ``False``
                           it will stop on the first error. Defaults to
                           ``False``.

--- a/flask_caching/backends/simple.py
+++ b/flask_caching/backends/simple.py
@@ -31,7 +31,7 @@ class SimpleCache(BaseCache):
                             specified on :meth:`~BaseCache.set`. A timeout of
                             0 indicates that the cache never expires.
     :param ignore_errors: If set to ``True`` the :meth:`~BaseCache.delete_many`
-                          method will ignore any errors that occured during the
+                          method will ignore any errors that occurred during the
                           deletion process. However, if it is set to ``False``
                           it will stop on the first error. Defaults to
                           ``False``.


### PR DESCRIPTION
There is a small typo in docs/index.rst, flask_caching/backends/filesystem.py, flask_caching/backends/simple.py.

Should read `occurred` rather than `occured`.

