### PR TITLE
setup.py: python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ class PyTest(TestCommand):
 
     def run_tests(self):
         import shlex
+
         # import here, cause outside the eggs aren't loaded
         import pytest
 
@@ -80,14 +81,9 @@ setup(
     packages=find_packages(exclude=("tests",)),
     zip_safe=False,
     platforms="any",
+    python_requires=">=3.5",
     install_requires=["Flask"],
-    tests_require=[
-        "pytest",
-        "pytest-cov",
-        "pytest-xprocess",
-        "pylibmc",
-        "redis"
-    ],
+    tests_require=["pytest", "pytest-cov", "pytest-xprocess", "pylibmc", "redis"],
     cmdclass={"test": PyTest},
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Since this package is only compatible with Python 3, we should use the `python_requires` argument in `setup.py` so that tools like `pip` don't try to install it on unsupported versions of Python.

https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

All other changes were automatically made by [`black`](https://github.com/psf/black) in my editor. I can revert them if you prefer.