### PR TITLE
Issue 189: stop marking wheels as py2 compatible

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,6 @@ all_files = 1
 [upload_sphinx]
 upload-dir = docs/_build/html
 
-[bdist_wheel]
-universal = 1
-
 [tool:pytest]
 addopts = -vvl --strict --cov=flask_caching --cov-report=term-missing
 norecursedirs = .* _* scripts {args}


### PR DESCRIPTION
This PR fixes #189 and no longer marks wheel distributions as universal, as they are no longer py2 compatible.