### PR TITLE
Add some basic logging.

### DIFF
--- a/flask_caching/backends/simplecache.py
+++ b/flask_caching/backends/simplecache.py
@@ -9,6 +9,7 @@
     :copyright: (c) 2010 by Thadeus Burgess.
     :license: BSD, see LICENSE for more details.
 """
+import logging
 from time import time
 
 from flask_caching.backends.base import BaseCache
@@ -17,6 +18,9 @@ try:
     import cPickle as pickle
 except ImportError:  # pragma: no cover
     import pickle
+
+
+logger = logging.getLogger(__name__)
 
 
 class SimpleCache(BaseCache):
@@ -53,6 +57,7 @@ class SimpleCache(BaseCache):
                     toremove.append(key)
             for key in toremove:
                 self._cache.pop(key, None)
+            logger.debug("evicted %d key(s): %r", len(toremove), toremove)
 
     def _normalize_timeout(self, timeout):
         timeout = BaseCache._normalize_timeout(self, timeout)
@@ -61,37 +66,61 @@ class SimpleCache(BaseCache):
         return timeout
 
     def get(self, key):
+        result = None
+        expired = False
+        hit_or_miss = "miss"
         try:
             expires, value = self._cache[key]
-            if expires == 0 or expires > time():
-                return pickle.loads(value)
-        except (KeyError, pickle.PickleError):
-            return None
+        except KeyError:
+            pass
+        else:
+            expired = expires != 0 and expires <= time()
+            if not expired:
+                hit_or_miss = "hit"
+                try:
+                    result = pickle.loads(value)
+                except Exception as exc:
+                    logger.error("get key %r -> %s", key, exc)
+        expiredstr = "(expired)" if expired else ""
+        logger.debug("get key %r -> %s %s", key, hit_or_miss, expiredstr)
+        return result
 
     def set(self, key, value, timeout=None):
         expires = self._normalize_timeout(timeout)
         self._prune()
-        self._cache[key] = (
-            expires,
-            pickle.dumps(value, pickle.HIGHEST_PROTOCOL),
-        )
+        item = (expires, pickle.dumps(value, pickle.HIGHEST_PROTOCOL))
+        self._cache[key] = item
+        logger.debug("set key %r", key)
         return True
 
     def add(self, key, value, timeout=None):
         expires = self._normalize_timeout(timeout)
         self._prune()
         item = (expires, pickle.dumps(value, pickle.HIGHEST_PROTOCOL))
-        if key in self._cache:
-            return False
-        self._cache.setdefault(key, item)
-        return True
+        updated = False
+        should_add = key not in self._cache
+        if should_add:
+            updated = self._cache.setdefault(key, item) != item
+        updatedstr = "updated" if updated else "not updated"
+        logger.debug("add key %r -> %s", key, updatedstr)
+        return should_add
 
     def delete(self, key):
-        return self._cache.pop(key, None) is not None
+        deleted = self._cache.pop(key, None) is not None
+        deletedstr = "deleted" if deleted else "not deleted"
+        logger.debug("delete key %r -> %s", key, deletedstr)
+        return deleted
 
     def has(self, key):
+        result = False
+        expired = False
         try:
             expires, value = self._cache[key]
-            return expires == 0 or expires > time()
         except KeyError:
-            return False
+            pass
+        else:
+            result = expires == 0 or expires > time()
+            expired = not result
+        expiredstr = "(expired)" if expired else ""
+        logger.debug("has key %r -> %s %s", key, result, expiredstr)
+        return result

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,7 +2,14 @@
 import random
 import time
 
+import pytest
 from flask_caching import Cache
+
+try:
+    import redis
+    HAS_NOT_REDIS = False
+except ImportError:
+    HAS_NOT_REDIS = True
 
 
 def test_cache_set(app, cache):
@@ -31,6 +38,7 @@ def test_cache_delete_many(app, cache):
     assert cache.get("hi") is not None
 
 
+@pytest.mark.skipif(HAS_NOT_REDIS, reason="requires Redis")
 def test_cache_unlink(app, redis_server):
     cache = Cache(config={"CACHE_TYPE": "redis"})
     cache.init_app(app)


### PR DESCRIPTION
Log results of cache operations for SimpleCache and FileSystemCache as a first step toward improving observability (#182, #17). The remaining cache backends can be updated similarly in followup work as desired.

Also include some minor code improvements (see my review comments).

Run `pytest` with `--log-cli-level=debug` for a quick way to view example log output from these changes.

UPDATE: [All tests passed](https://travis-ci.com/github/jab/flask-caching/builds/204971572) on Travis. ✔️