### PR TITLE
Add test_generic_get_bytes

### DIFF
--- a/tests/test_backend_cache.py
+++ b/tests/test_backend_cache.py
@@ -131,6 +131,10 @@ class GenericCacheTests(CacheTestsBase):
         assert c.has("foo") in (False, 0)
         assert c.has("spam") in (False, 0)
 
+    def test_generic_get_bytes(self, c):
+        assert c.set("foo", b"bar")
+        assert c.get("foo") == b"bar"
+
 
 class TestSimpleCache(GenericCacheTests):
     @pytest.fixture


### PR DESCRIPTION
Some serializers, like JSON, don't support byte strings and those need to be handled as a special case. It might be useful to test for that anyway.