### PR TITLE
docs: Fix trivial typos on docstrings

### DIFF
--- a/flask_caching/__init__.py
+++ b/flask_caching/__init__.py
@@ -382,8 +382,8 @@ class Cache(object):
                               renewal of cached functions.
 
         :param response_filter: Default None. If not None, the callable is
-                                invoked after the cached funtion evaluation,
-                                and is given one arguement, the response
+                                invoked after the cached function evaluation,
+                                and is given one argument, the response
                                 content. If the callable returns False, the
                                 content will not be cached. Useful to prevent
                                 caching of code 500 responses.
@@ -707,7 +707,7 @@ class Cache(object):
         #: Inspect the arguments to the function
         #: This allows the memoization to be the same
         #: whether the function was called with
-        #: 1, b=2 is equivilant to a=1, b=2, etc.
+        #: 1, b=2 is equivalent to a=1, b=2, etc.
         new_args = []
         arg_num = 0
         args_to_ignore = kwargs.pop("args_to_ignore", None) or []

--- a/flask_caching/backends/base.py
+++ b/flask_caching/backends/base.py
@@ -116,7 +116,7 @@ class BaseCache(object):
         :param value: the value for the key
         :param timeout: the cache timeout for the key in seconds (if not
                         specified, it uses the default timeout). A timeout of
-                        0 idicates that the cache never expires.
+                        0 indicates that the cache never expires.
         :returns: Same as :meth:`set`, but also ``False`` for already
                   existing keys.
         :rtype: boolean
@@ -129,7 +129,7 @@ class BaseCache(object):
         :param mapping: a mapping with the keys/values to set.
         :param timeout: the cache timeout for the key in seconds (if not
                         specified, it uses the default timeout). A timeout of
-                        0 idicates that the cache never expires.
+                        0 indicates that the cache never expires.
         :returns: Whether all given keys have been set.
         :rtype: boolean
         """

--- a/flask_caching/backends/memcache.py
+++ b/flask_caching/backends/memcache.py
@@ -269,7 +269,7 @@ class SASLMemcachedCache(MemcachedCache):
 
 class SpreadSASLMemcachedCache(SASLMemcachedCache):
     """Simple Subclass of SASLMemcached client that will spread the value
-    across multiple keys if they are bigger than a given treshhold.
+    across multiple keys if they are bigger than a given threshold.
 
     Spreading requires using pickle to store the value, which can significantly
     impact the performance.

--- a/flask_caching/backends/nullcache.py
+++ b/flask_caching/backends/nullcache.py
@@ -13,7 +13,7 @@ from flask_caching.backends.base import BaseCache
 
 
 class NullCache(BaseCache):
-    """A cache that doesn't cache.  This can be useful for unit testing.
+    """A cache that doesn't cache. This can be useful for unit testing.
 
     :param default_timeout: a dummy parameter that is ignored but exists
                             for API compatibility with other caches.

--- a/flask_caching/backends/simplecache.py
+++ b/flask_caching/backends/simplecache.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 class SimpleCache(BaseCache):
-    """Simple memory cache for single process environments.  This class exists
+    """Simple memory cache for single process environments. This class exists
     mainly for the development server and is not 100% thread safe.  It tries
     to use as many atomic operations as possible and no locks for simplicity
     but it could happen under heavy load that keys are added multiple times.


### PR DESCRIPTION
Quite useless, but I just fixed some typos that I've stumbled upon on some docstrings around the codebase.