### PR TITLE
feat: use redis connection string for cluster

### DIFF
--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -229,9 +229,14 @@ class RedisClusterCache(RedisCache):
         if kwargs.get("decode_responses", None):
             raise ValueError("decode_responses is not supported by RedisCache.")
 
+        try:
+            from redis import RedisCluster
+            from redis.cluster import ClusterNode
+        except ImportError as e:
+            raise RuntimeError("no redis.cluster module found") from e
+
         if kwargs.get("redis_url", None):
             cluster = RedisCluster.from_url(kwargs["redis_url"])
-
         else:
             try:
                 nodes = [(node.split(":")) for node in cluster.split(",")]

--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -56,7 +56,7 @@ class RedisCache(BaseCache, CachelibRedisCache):
             db=db,
             default_timeout=default_timeout,
             key_prefix=key_prefix,
-            **kwargs
+            **kwargs,
         )
 
     @classmethod
@@ -176,7 +176,7 @@ class RedisSentinelCache(RedisCache):
             password=password,
             db=db,
             sentinel_kwargs=sentinel_kwargs,
-            **kwargs
+            **kwargs,
         )
 
         self._write_client = sentinel.master_for(master)
@@ -229,33 +229,31 @@ class RedisClusterCache(RedisCache):
         if kwargs.get("decode_responses", None):
             raise ValueError("decode_responses is not supported by RedisCache.")
 
-        try:
-            from redis import RedisCluster
-            from redis.cluster import ClusterNode
-        except ImportError as e:
-            raise RuntimeError("no redis.cluster module found") from e
+        if kwargs.get("redis_url", None):
+            cluster = RedisCluster.from_url(kwargs["redis_url"])
 
-        try:
-            nodes = [(node.split(":")) for node in cluster.split(",")]
-            startup_nodes = [
-                ClusterNode(node[0].strip(), node[1].strip()) for node in nodes
-            ]
-        except IndexError as e:
-            raise ValueError(
-                "Please give the correct cluster argument "
-                "e.g. host1:port1,host2:port2,host3:port3"
-            ) from e
+        else:
+            try:
+                nodes = [(node.split(":")) for node in cluster.split(",")]
+                startup_nodes = [
+                    ClusterNode(node[0].strip(), node[1].strip()) for node in nodes
+                ]
+            except IndexError as e:
+                raise ValueError(
+                    "Please give the correct cluster argument "
+                    "e.g. host1:port1,host2:port2,host3:port3"
+                ) from e
 
-        # Skips the check of cluster-require-full-coverage config,
-        # useful for clusters without the CONFIG command (like aws)
-        skip_full_coverage_check = kwargs.pop("skip_full_coverage_check", True)
+            # Skips the check of cluster-require-full-coverage config,
+            # useful for clusters without the CONFIG command (like aws)
+            skip_full_coverage_check = kwargs.pop("skip_full_coverage_check", True)
 
-        cluster = RedisCluster(
-            startup_nodes=startup_nodes,
-            password=password,
-            skip_full_coverage_check=skip_full_coverage_check,
-            **kwargs
-        )
+            cluster = RedisCluster(
+                startup_nodes=startup_nodes,
+                password=password,
+                skip_full_coverage_check=skip_full_coverage_check,
+                **kwargs,
+            )
 
         self._write_client = cluster
         self._read_client = cluster
@@ -268,6 +266,7 @@ class RedisClusterCache(RedisCache):
                 password=config.get("CACHE_REDIS_PASSWORD", ""),
                 default_timeout=config.get("CACHE_DEFAULT_TIMEOUT", 300),
                 key_prefix=config.get("CACHE_KEY_PREFIX", ""),
+                redis_url=config.get("CACHE_REDIS_URL", ""),
             )
         )
         return cls(*args, **kwargs)


### PR DESCRIPTION
Users can now use `CACHE_REDIS_URL` for `RedisClusterCache`. e.g.

```
cache = flask_caching.Cache(
    config={
        "CACHE_TYPE": "RedisClusterCache",
        "CACHE_REDIS_URL": REDIS_URL,
    }
)
```

- fixes #551

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
