### PR TITLE
Pass CACHE_OPTIONS as kwargs to redis_from_url

### DIFF
--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -84,7 +84,8 @@ class RedisCache(BaseCache, CachelibRedisCache):
 
         redis_url = config.get("CACHE_REDIS_URL")
         if redis_url:
-            kwargs["host"] = redis_from_url(redis_url, db=kwargs.pop("db", None))
+            redis_kwargs = config.pop("CACHE_OPTIONS", None) or {}
+            kwargs["host"] = redis_from_url(redis_url, db=kwargs.pop("db", None), **redis_kwargs)
 
         new_class = cls(*args, **kwargs)
 


### PR DESCRIPTION
This PR passes `CACHE_OPTIONS` as **kwargs to redis_from_url so complex option be can passed to redis client. 

```
cache = Cache(
    config={
        "CACHE_TYPE": os.environ.get("CACHE_TYPE", "RedisCache"),
        "CACHE_REDIS_URL": redis_cache_url(),
        "CACHE_OPTIONS": {
            "retry": Retry(ExponentialBackoff(cap=2, base=1), 3),
            "retry_on_error": [ConnectionError, TimeoutError, ConnectionRefusedError, ConnectionResetError],
            "health_check_interval": 1,
        },
    }
)
```

- fixes #443

