### PR TITLE
fix checking for pytest-xprocess

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@ Changelog
 =========
 
 
+Version 2.4.0
+-------------
+
+- Fixed tests to detect ``pytest-xprocess`` against versions 0.19.0 and newer correctly. :issue:`592`
+
+
 Version 2.3.0
 -------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import pytest
 import flask_caching as fsc
 
 try:
-    __import__("pytest_xprocess")
     from xprocess import ProcessStarter
 except ImportError:
 


### PR DESCRIPTION
Fix conftest not to require `pytest_xprocess` module.  This module has been removed back in 2021, and it is missing since pytest-xprocess 0.19.0.  Checking for just `xprocess` is fine, and makes all tests run again.

- fixes #592

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
