### PR TITLE
Update intersphinx_mapping for Sphinx 8 compatibility (#598)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@ Changelog
 =========
 
 
+Unreleased
+----------
+
+- Update ``intersphinx_mapping`` for Sphinx 8 compatibility. :pr:`599`, :issue:`598`
+
+
 Version 2.3.0
 -------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -362,4 +362,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/3/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->
This makes the `intersphinx_mapping` in `docs/conf.py` forward-compatible with Spinx 8 by changing it from


```python
intersphinx_mapping = {"https://docs.python.org/3/": None}
```

to

```pythohn
intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
```

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #598

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change. **N/A; test by building and inspecting the documentation**
- [ ] Add or update relevant docs, in the docs folder and in code. **N/A; nothing to document**
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs. **N/A; no code changes**
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
