### PR TITLE
fixes #626

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -548,6 +548,7 @@ Set ``CACHE_TYPE`` to ``RedisSentinel`` to use this type.  The old name,
 - CACHE_REDIS_SENTINELS
 - CACHE_REDIS_SENTINEL_MASTER
 - CACHE_REDIS_PASSWORD
+- CACHE_REDIS_SENTINEL_PASSWORD
 - CACHE_REDIS_DB
 
 Entries in CACHE_OPTIONS are passed to the redis client as ``**kwargs``


### PR DESCRIPTION
This fixes #626 where `CACHE_REDIS_SENTINEL_PASSWORD` was not documented as an option of the `RedisSentinel` cache type.

- fixes #626