### PR TITLE
Fix memoize/cached under Python 3.14 TYPE_CHECKING annotations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Version 2.4.0
 - Pass CACHE_OPTIONS as kwargs to redis_from_url. :pr:`591`
 - Pass sentinel_kwargs to redis client via CACHE_OPTIONS :pr:`626`
 - Fix ``response_hit_indication`` return True always. :pr:`579`, :pr:`596`, :issue:`595`, :issue:`570`
+- Use ``FORWARDREF`` annotation format when introspecting decorated
+  functions so that ``@memoize`` / ``@cached`` work with
+  ``TYPE_CHECKING``-only annotations on Python 3.14. :issue:`636`
 
 
 Version 2.3.1

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -447,7 +447,7 @@ class Cache:
                 # Convert non-keyword arguments (which is the way
                 # `make_cache_key` expects them) to keyword arguments
                 # (the way `url_for` expects them)
-                argspec_args = inspect.getfullargspec(f).args
+                argspec_args = get_arg_names(f)
 
                 for arg_name, arg in zip(argspec_args, args, strict=False):
                     kwargs[arg_name] = arg
@@ -733,11 +733,8 @@ class Cache:
         bypass_cache = False
 
         if callable(unless):
-            argspec = inspect.getfullargspec(unless)
-            has_args = len(argspec.args) > 0 or argspec.varargs or argspec.varkw
-
             # If unless() takes args, pass them in.
-            if has_args:
+            if wants_args(unless):
                 if unless(f, *args, **kwargs) is True:
                     bypass_cache = True
             elif unless() is True:

--- a/src/flask_caching/utils.py
+++ b/src/flask_caching/utils.py
@@ -1,6 +1,15 @@
 import inspect
 import string
+import sys
 from collections.abc import Callable
+
+if sys.version_info >= (3, 14):
+    import annotationlib
+
+    def _signature(f: Callable) -> inspect.Signature:
+        return inspect.signature(f, annotation_format=annotationlib.Format.FORWARDREF)
+else:
+    _signature = inspect.signature
 
 TEMPLATE_FRAGMENT_KEY_TEMPLATE = "_template_fragment_cache_%s%s"
 # Used to remove control characters and whitespace from cache keys.
@@ -10,9 +19,10 @@ null_control = ({k: None for k in del_chars},)
 
 
 def wants_args(f: Callable) -> bool:
-    """Check if the function wants any arguments"""
-    arg_spec = inspect.getfullargspec(f)
-    return bool(arg_spec.args or arg_spec.varargs or arg_spec.varkw)
+    """Check if the function wants any positional, *args, or **kwargs arguments."""
+    return any(
+        p.kind != inspect.Parameter.KEYWORD_ONLY for p in get_function_parameters(f)
+    )
 
 
 def get_function_parameters(f: Callable) -> list:
@@ -20,7 +30,7 @@ def get_function_parameters(f: Callable) -> list:
     :param f
     :return: Parameter list of function
     """
-    return list(inspect.signature(f).parameters.values())
+    return list(_signature(f).parameters.values())
 
 
 def get_arg_names(f: Callable) -> list[str]:

--- a/tests/test_py314_annotations.py
+++ b/tests/test_py314_annotations.py
@@ -1,0 +1,55 @@
+"""Regression tests for issue #636.
+
+On Python 3.14+, ``inspect.signature`` and ``inspect.getfullargspec`` eagerly
+evaluate annotations via PEP 649's ``__annotate__``. Functions whose
+annotations reference names defined only under ``if TYPE_CHECKING:`` must
+still be memoizable / cacheable.
+"""
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+
+    class TypeCheckingOnly:
+        pass
+
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="requires Python 3.14 __annotate__ / PEP 649 behavior",
+)
+
+
+def test_memoize_with_type_checking_annotation(cache):
+    @cache.memoize(60)
+    def fetch(x: int) -> TypeCheckingOnly:
+        return x * 2
+
+    assert fetch(3) == 6
+    # Cache-hit path also goes through get_function_parameters.
+    assert fetch(3) == 6
+
+
+def test_cached_with_type_checking_annotation(app, cache):
+    @app.route("/py314-annot")
+    @cache.cached(60)
+    def view(extra: TypeCheckingOnly = None):
+        return "ok"
+
+    client = app.test_client()
+    assert client.get("/py314-annot").data == b"ok"
+    assert client.get("/py314-annot").data == b"ok"
+
+
+def test_memoize_unless_with_type_checking_annotation(cache):
+    def skip(*args, **kwargs) -> TypeCheckingOnly:
+        return False
+
+    @cache.memoize(60, unless=skip)
+    def fetch(x: int) -> TypeCheckingOnly:
+        return x + 1
+
+    assert fetch(1) == 2


### PR DESCRIPTION
## Summary

Fixes #636.

On Python 3.14, `inspect.signature(f)` and `inspect.getfullargspec(f)` eagerly evaluate annotations via PEP 649's `__annotate__`. Any function decorated with `@Cache.memoize` or `@Cache.cached` whose annotations reference names only defined under `if TYPE_CHECKING:` raises `NameError` at decoration / first-call time.

This PR:

- Routes signature introspection in `utils.py` through a `_signature(f)` helper that passes `annotation_format=annotationlib.Format.FORWARDREF` on Python 3.14+. FORWARDREF leaves unresolvable names as `ForwardRef` objects instead of raising. `get_function_parameters` only reads parameter names, so this is a pure internal change.
- Rewrites `wants_args` to use `inspect.signature` (via `_signature`) instead of `inspect.getfullargspec`, which has the same eager-evaluation problem and no `annotation_format` parameter.
- Replaces the two remaining `inspect.getfullargspec` call sites in `__init__.py` with `get_arg_names` / `wants_args`.

## Test plan

- [x] Added `tests/test_py314_annotations.py` covering `memoize`, `cached`, and `unless` with unquoted `TYPE_CHECKING`-only annotations — these fail on `master` with 3.14 and pass with this change.
- [x] Full test suite passes on Python 3.14.4 and 3.13.12 (one pre-existing failure unrelated to this PR: `test_memoize_classfunc_repr`).
- [x] `mypy` and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)