### PR TITLE
docs: clarify @memoize identity uses repr, not id() (#555)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Docs: clarify that ``@memoize`` uses ``repr(obj)``
+  (or ``__caching_id__``) for the ``self``/``cls`` identity, not Python's
+  :func:`id`. :issue:`555`
+
+
 Version 2.4.0
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -174,8 +174,12 @@ In memoization, the functions arguments are also included into the cache_key.
     :meth:`~Cache.memoize` are effectively the same.
 
 Memoize is also designed for methods, since it will take into account
-the `identity <http://docs.python.org/library/functions.html#id>`_. of the
-'self' or 'cls' argument as part of the cache key.
+the identity of the ``self`` or ``cls`` argument as part of the cache
+key. By default this identity is derived from ``repr(obj)`` (or
+``obj.__caching_id__()`` if the object provides one). It is **not**
+based on Python's built-in :func:`id`, so two distinct instances that
+share the same ``repr`` (for example two ORM objects loaded for the
+same row) will share a memoize cache entry.
 
 The theory behind memoization is that if you have a function you need
 to call several times in one request, it would only be calculated the first


### PR DESCRIPTION
## Summary

The `Memoize` section in `docs/index.rst` describes the
`self`/`cls` cache-key identity by linking the word *identity* to
Python's built-in :func:`id`. The actual implementation in
`flask_caching.utils.get_id` is `getattr(obj, "__caching_id__", repr)(obj)`,
i.e. `repr(obj)` by default, never `id()`. Reword the paragraph to
describe what really happens, so users don't expect per-instance
identity semantics (and don't get surprised when two ORM rows
representing the same record share a cache entry).

Fixes #555.

## Context

`get_id` was introduced (and documented under "BREAKING: Allow to use
`__caching_id__` rather than `__repr__`...", v1.8.0 PR #123) precisely
so users could override the identity function. The current docs still
point readers to the wrong primitive.

## Changes

- `docs/index.rst`: replace the `id` hyperlink with a 4-line
  explanation citing `repr(obj)` and `__caching_id__`.
- `CHANGES.rst`: add Unreleased docs entry.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/pallets-eco/flask-caching.git /tmp/fc-555 && cd /tmp/fc-555

# --- BEFORE: origin/main, expect misleading id() link ---
git checkout origin/main
grep -n "library/functions.html#id" docs/index.rst
# Expected: docs/index.rst line points to Python's id() reference

# --- AFTER: this branch, expect repr-based explanation, no id link ---
git fetch https://github.com/jbbqqf/flask-caching.git docs/555-memoize-identity-link
git checkout FETCH_HEAD
grep -n "library/functions.html#id" docs/index.rst || echo "no misleading id link"
grep -n "repr(obj)" docs/index.rst
# Expected: "no misleading id link" + line with "repr(obj)"
```

## What I ran locally

```
$ python3.11 -m venv .venv && . .venv/bin/activate
$ uv pip install --group docs  # installs sphinx + extensions
$ cd docs && sphinx-build -W -b dirhtml . _build/dirhtml
...
build succeeded.

$ grep "repr(obj)" _build/dirhtml/index.html
... repr(obj) ... or __caching_id__()  ...
```

Docs build with `-W` (warnings as errors) — same flags as the RTD
build at `.readthedocs.yaml`.

The runtime behavior is already covered by existing tests:
`tests/test_memoize.py::test_memoize_classfunc_repr` (override
`__caching_id__`) and `test_memoize_classfunc` (default identity).

## Edge cases

| # | Scenario | Old docs would imply | New docs say | Verified by |
|---|----------|----------------------|--------------|-------------|
| 1 | Two distinct instances with same `repr` | distinct cache entries (id() differs) | same cache entry (repr matches) | new doc text + existing `test_memoize_classfunc` |
| 2 | Object overrides `__caching_id__` | not mentioned | "or `__caching_id__()` if the object provides one" | `tests/test_memoize.py::test_memoize_classfunc_repr` |
| 3 | ORM row reloaded twice | new id() => new cache key (wrong) | same repr => same cache key | new doc text |

## Risk / blast radius

Docs-only. No code changes. Renders cleanly with the project's RTD
build command `sphinx-build -W -b dirhtml docs $OUT`.

---

*PR drafted with assistance from Claude Code (Anthropic). The change
was reviewed manually against pallets-eco/flask-caching's source
(`src/flask_caching/utils.py:54-55`). The reproducer block above is the
one I used during development; reviewers can paste it verbatim.*
