### PR TITLE
feat: forward kwargs to RedisCluster.from_url in RedisCluster

### DIFF
--- a/src/flask_caching/backends/rediscache.py
+++ b/src/flask_caching/backends/rediscache.py
@@ -234,8 +234,11 @@ class RedisClusterCache(RedisCache):
         except ImportError as e:
             raise RuntimeError("no redis.cluster module found") from e
 
-        if kwargs.get("redis_url", None):
-            cluster = RedisCluster.from_url(kwargs["redis_url"])
+        redis_url = kwargs.pop("redis_url", None)
+
+        # Use URL-based connection if provided, otherwise use startup nodes.
+        if redis_url:
+            cluster = RedisCluster.from_url(redis_url, **kwargs)
         else:
             try:
                 nodes = [(node.split(":")) for node in cluster.split(",")]


### PR DESCRIPTION
## Summary

Fixes #649 

`RedisClusterCache` was not forwarding extra kwargs to `RedisCluster.from_url`, making it impossible to pass connection options like `dynamic_startup_nodes` or `require_full_coverage` when using `CACHE_REDIS_URL`.

## Changes

- Forward `**kwargs` to `RedisCluster.from_url` in the URL-based path

## Checklist
- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.