### PR TITLE
Don't define class-scoped fixtures as instance methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 - Docs: clarify that ``@memoize`` uses ``repr(obj)``
   (or ``__caching_id__``) for the ``self``/``cls`` identity, not Python's
   :func:`id`. :issue:`555`
+- Fix test failure with pytest 9.1. :issue:`651`
 
 
 Version 2.4.0

--- a/tests/test_backend_cache.py
+++ b/tests/test_backend_cache.py
@@ -169,7 +169,8 @@ class TestRedisCache(GenericCacheTests):
         return "werkzeug-test-case:"
 
     @pytest.fixture(scope="class", autouse=True)
-    def requirements(self, redis_server):
+    @classmethod
+    def requirements(cls, redis_server):
         pass
 
     @pytest.fixture(params=(None, False, True, gen_key_prefix))
@@ -239,7 +240,8 @@ class TestMemcachedCache(GenericCacheTests):
     _guaranteed_deletes = False
 
     @pytest.fixture(scope="class", autouse=True)
-    def requirements(self, memcache_server):
+    @classmethod
+    def requirements(cls, memcache_server):
         pass
 
     @pytest.fixture
@@ -268,7 +270,8 @@ class TestMemcachedCache(GenericCacheTests):
 
 class TestNullCache(CacheTestsBase):
     @pytest.fixture(scope="class", autouse=True)
-    def make_cache(self):
+    @classmethod
+    def make_cache(cls):
         return backends.NullCache
 
     def test_has(self, c):


### PR DESCRIPTION
This is deprecated as of pytest 9.1; see
https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method.

- fixes #651

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.