### PR TITLE
Call memoize forced_update callbacks once

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Version 2.4.2
+-------------
+
+Unreleased
+
+- Call ``@memoize`` ``forced_update`` callbacks once per decorated function
+  call instead of once while making the key and again before cache lookup.
+  :issue:`387`
+
+
 Version 2.4.1
 -------------
 

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -572,7 +572,7 @@ class Cache:
         version_data_list = list(self.cache.get_many(*fetch_keys))
         dirty = False
 
-        if (
+        if forced_update is True or (
             callable(forced_update)
             and (
                 forced_update(*(args or ()), **(kwargs or {}))
@@ -859,9 +859,7 @@ class Cache:
                     source_check = self.source_check
 
                 try:
-                    cache_key = decorated_function.make_cache_key(f, *args, **kwargs)
-
-                    if (
+                    forced_update_result = (
                         callable(forced_update)
                         and (
                             forced_update(*args, **kwargs)
@@ -869,7 +867,18 @@ class Cache:
                             else forced_update()
                         )
                         is True
-                    ):
+                    )
+
+                    cache_key = self._memoize_make_cache_key(
+                        make_name=make_name,
+                        timeout=decorated_function,
+                        forced_update=forced_update_result,
+                        hash_method=hash_method,
+                        source_check=source_check,
+                        args_to_ignore=args_to_ignore,
+                    )(f, *args, **kwargs)
+
+                    if forced_update_result:
                         rv = None
                         found = False
                     else:
@@ -919,7 +928,7 @@ class Cache:
             decorated_function.make_cache_key = self._memoize_make_cache_key(
                 make_name=make_name,
                 timeout=decorated_function,
-                forced_update=forced_update,
+                forced_update=False,
                 hash_method=hash_method,
                 source_check=source_check,
                 args_to_ignore=args_to_ignore,

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -527,21 +527,18 @@ def test_memoize_forced_update_parameters(app, cache):
 
         # Save the value for later inspection
         result = memoized_func(5, 2)
-        # forced_update_func should have been called twice; once by memoize
-        # itself, once by _memoize_version…
-        assert call_counter[1] == 2
+        # forced_update_func should have been called once by memoize itself.
+        assert call_counter[1] == 1
         # …with the values we called the function with
         assert call_params[0] == (5, 2)
-        assert call_params[1] == (5, 2)
         time.sleep(1)
 
         # Calling the function again should return the cached value
         assert memoized_func(5, 2) == result
-        # forced_update_func should have been called two more times…
-        assert call_counter[1] == 4
+        # forced_update_func should have been called one more time…
+        assert call_counter[1] == 2
         # …with the values we called the function with
-        assert call_params[2] == (5, 2)
-        assert call_params[3] == (5, 2)
+        assert call_params[1] == (5, 2)
 
         # Tell forced_update_func to return True next time
         forced_update = True
@@ -550,22 +547,20 @@ def test_memoize_forced_update_parameters(app, cache):
         # …which, due to the random number in the function, should be different
         # from the old one
         assert new_result != result
-        # forced_update_func should have been called two more times again…
-        assert call_counter[1] == 6
+        # forced_update_func should have been called one more time again…
+        assert call_counter[1] == 3
         # …with the values we called the function with
-        assert call_params[4] == (5, 2)
-        assert call_params[5] == (5, 2)
+        assert call_params[2] == (5, 2)
 
         # Now stop forced updating again
         forced_update = False
         time.sleep(1)
         # The function should return the same value as it did last time
         assert memoized_func(5, 2) == new_result
-        # forced_update_func should have been called two more times again…
-        assert call_counter[1] == 8
+        # forced_update_func should have been called one more time again…
+        assert call_counter[1] == 4
         # …with the values we called the function with
-        assert call_params[6] == (5, 2)
-        assert call_params[7] == (5, 2)
+        assert call_params[3] == (5, 2)
 
 
 def test_memoize_multiple_arg_kwarg_calls(app, cache):


### PR DESCRIPTION
Fixes #387

## Reproduction

With `@cache.memoize(forced_update=callback)`, a minimal SimpleCache script that calls the memoized function twice invokes `callback` four times even though there are only two decorated function calls. The callback is evaluated once while building the memoize cache key and once again before cache lookup.

## Root cause

`decorated_function.make_cache_key(...)` calls `_memoize_version(..., forced_update=forced_update)`, which evaluates the callable. The memoize wrapper then evaluates the same callable again to decide whether to bypass the cached value.

## Fix

The memoize wrapper now evaluates `forced_update` once per decorated call and passes that boolean into version handling so the version TTL refresh behavior is preserved when forced updates occur. The public memoize `make_cache_key` no longer evaluates the `forced_update` callback as a side effect.

## Compatibility notes

This preserves the existing cache key format and forced-update refresh behavior while avoiding duplicate callback side effects. Existing callbacks still receive the same positional and keyword arguments.

## Validation

- Reproduced before the fix: minimal SimpleCache script reported `forced_calls=4 function_calls=1` and failed an assertion expecting 2 forced-update calls.
- Regression check: `python -m pytest tests\test_memoize.py::test_memoize_forced_update_parameters` fails with the source fix reverted (`assert 2 == 1`) and passes with the fix.
- `python -m pytest` -> `123 passed, 81 skipped, 4 warnings` on Python 3.13.14 / Windows. The skipped tests are backend-dependent tests for unavailable external cache/server combinations.
- `python -m ruff check src\flask_caching\__init__.py tests\test_memoize.py` -> passed.
- `pre-commit run --files src\flask_caching\__init__.py tests\test_memoize.py CHANGES.rst` -> passed.