### PR TITLE
Fix memoize cache-key collision on falsy default arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Version 2.4.2
+-------------
+
+Unreleased
+
+- Fix a ``@memoize`` cache-key collision when a parameter has a falsy
+  default (e.g. ``0``, ``""``, ``False``): calling with the default was
+  keyed the same as passing ``None``, returning the wrong cached result.
+  :pr:`656`
+
+
 Version 2.4.1
 -------------
 

--- a/src/flask_caching/__init__.py
+++ b/src/flask_caching/__init__.py
@@ -691,7 +691,7 @@ class Cache:
             elif arg_num < len(args):
                 arg = args[arg_num]
                 arg_num += 1
-            elif arg_default:
+            elif arg_default is not None:
                 arg = arg_default
                 arg_num += 1
             else:

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -32,6 +32,24 @@ def test_memoize(app, cache):
         assert big_foo(5, 3) != result2
 
 
+def test_memoize_falsy_default_argument(app, cache):
+    with app.test_request_context():
+        runs = []
+
+        @cache.memoize()
+        def f(a, b=0):
+            runs.append((a, b))
+            return f"{a}:{b}"
+
+        # A falsy default (0) must not collide with an explicit None.
+        assert f(1, None) == "1:None"
+        assert f(1) == "1:0"
+        assert f(1, 0) == "1:0"
+        assert f(1, b=0) == "1:0"
+        # None and the default 0 are distinct; the three b=0 forms share a key.
+        assert runs == [(1, None), (1, 0)]
+
+
 def test_memoize_hashes(app, cache, hash_method):
     with app.test_request_context():
 


### PR DESCRIPTION
### Summary

`Cache._memoize_kwargs_to_args()` decides whether to fill in a parameter's default with a truthiness test:

```python
elif arg_default:          # src/flask_caching/__init__.py
    arg = arg_default
    arg_num += 1
else:
    arg = None
    arg_num += 1
```

`get_arg_default()` returns the parameter's actual default, or `None` when there is no default. So when a parameter has a **falsy** default (`0`, `""`, `False`, `[]`, `0.0`), `elif arg_default:` is `False` and the code falls through to `arg = None`. The generated cache key then treats "called with the default" identically to "called with `None`" — a **collision that returns the wrong cached result**.

### Reproduce

```python
@cache.memoize()
def f(a, b=0):
    return f"{a}:{b}"

f(1, None)   # -> "1:None"   (cached under (1, None))
f(1)         # b defaults to 0; should be "1:0"
             # actual: "1:None"  <- wrong, function body never runs
```

### Fix

Distinguish "has a (falsy) default" from "no default":

```python
elif arg_default is not None:
    arg = arg_default
    arg_num += 1
```

Behavior is unchanged for parameters with no default and for `default=None` (both still map to `None`, the correct key in those cases). Only falsy-but-not-`None` defaults are now keyed by their real value — so `f(1)`, `f(1, 0)` and `f(1, b=0)` share one entry (the documented equivalence) while `f(1, None)` stays distinct.

### Tests

Added `test_memoize_falsy_default_argument`, which fails on `main` (`f(1)` returns `"1:None"`) and passes with the fix. Full `tests/test_memoize.py` → `41 passed`.